### PR TITLE
Move route_agent to its own directory module

### DIFF
--- a/examples/guide/src/guide.rs
+++ b/examples/guide/src/guide.rs
@@ -5,7 +5,7 @@ use yew::prelude::*;
 use yew::Properties;
 use yew_router::components::RouterLink;
 use yew_router::matcher::RouteMatcher;
-use yew_router::route_agent::RouteRequest::GetCurrentRoute;
+use yew_router::agent::RouteRequest::GetCurrentRoute;
 use yew_router::{RouteAgent, RouteInfo};
 
 pub struct Guide {

--- a/examples/routing_component/src/b_component.rs
+++ b/examples/routing_component/src/b_component.rs
@@ -6,7 +6,7 @@ use yew::Properties;
 use yew_router::matcher::FromMatches;
 use yew_router::matcher::FromMatchesError;
 use yew_router::route;
-use yew_router::route_agent::RouteRequest;
+use yew_router::agent::RouteRequest;
 use yew_router::{RouteAgent, RouteInfo};
 
 pub struct BModel {

--- a/yew_router/src/agent/bridge.rs
+++ b/yew_router/src/agent/bridge.rs
@@ -1,0 +1,58 @@
+//! Bridge to RouteAgent.
+use yew::{Bridge, Callback};
+use yew::agent::Context;
+use std::fmt::{Debug, Formatter, Error as FmtError};
+use std::ops::{Deref, DerefMut};
+use crate::route_info::RouteInfo;
+use crate::agent::{RouterState, RouteAgent};
+use yew::agent::Bridged;
+
+
+
+
+/// A simplified interface to the router agent.
+pub struct RouteAgentBridge<T>(Box<dyn Bridge<RouteAgent<T>>>)
+    where
+            for<'de> T: RouterState<'de>;
+
+impl<T> RouteAgentBridge<T>
+    where
+            for<'de> T: RouterState<'de>,
+{
+    /// Creates a new bridge.
+    pub fn new(callback: Callback<RouteInfo<T>>) -> Self {
+        let router_agent = RouteAgent::bridge(callback);
+        RouteAgentBridge(router_agent)
+    }
+
+    /// Experimental, may be removed
+    ///
+    /// Directly spawn a new Router
+    pub fn spawn(callback: Callback<RouteInfo<T>>) -> Self {
+        use yew::agent::Discoverer;
+        let router_agent = Context::spawn_or_join(callback);
+        RouteAgentBridge(router_agent)
+    }
+}
+
+/// A wrapper around the bridge
+//pub (crate) struct RouteAgentBridge<T: for<'de> YewRouterState<'de>>(pub Box<dyn Bridge<RouteAgent<T>>>);
+
+impl<T: for<'de> RouterState<'de>> Debug for RouteAgentBridge<T> {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
+        f.debug_tuple("RouteAgentBridge").finish()
+    }
+}
+
+impl<T: for<'de> RouterState<'de>> Deref for RouteAgentBridge<T> {
+    type Target = Box<dyn Bridge<RouteAgent<T>>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl<T: for<'de> RouterState<'de>> DerefMut for RouteAgentBridge<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/yew_router/src/components/router_button.rs
+++ b/yew_router/src/components/router_button.rs
@@ -1,5 +1,5 @@
 //! A component wrapping a <button/> tag that changes the route.
-use crate::route_agent::{RouteRequest, RouteSenderBridge, Void};
+use crate::agent::{RouteRequest, RouteSenderBridge, Void};
 use crate::route_info::RouteInfo;
 use yew::prelude::*;
 

--- a/yew_router/src/components/router_link.rs
+++ b/yew_router/src/components/router_link.rs
@@ -1,5 +1,5 @@
 //! A component wrapping an <a/> tag that changes the route.
-use crate::route_agent::{RouteRequest, RouteSenderBridge, Void};
+use crate::agent::{RouteRequest, RouteSenderBridge, Void};
 use crate::route_info::RouteInfo;
 use yew::prelude::*;
 

--- a/yew_router/src/lib.rs
+++ b/yew_router/src/lib.rs
@@ -51,10 +51,10 @@
 pub mod route_service;
 
 #[cfg(feature = "router_agent")]
-pub mod route_agent;
+pub mod agent;
 #[cfg(feature = "router_agent")]
 /// Alias to [RouteAgent<()>](struct.RouteAgent.html).
-pub type RouteAgent = route_agent::RouteAgent<()>;
+pub type RouteAgent = agent::RouteAgent<()>;
 
 pub mod route_info;
 /// Alias to [RouteInfo<()>](struct.RouteInfo.html).

--- a/yew_router/src/router_component/mod.rs
+++ b/yew_router/src/router_component/mod.rs
@@ -3,7 +3,7 @@ pub mod route;
 pub mod router;
 
 
-use crate::route_agent::RouterState;
+use crate::agent::RouterState;
 
 /// Alias to [Router<()>](struct.Router.html)
 ///

--- a/yew_router/src/router_component/router.rs
+++ b/yew_router/src/router_component/router.rs
@@ -1,8 +1,7 @@
 //! Router Component.
 
 use crate::router_component::route::Route;
-use crate::route_agent::RouteAgentBridge;
-use crate::route_agent::RouteRequest;
+use crate::agent::{bridge::RouteAgentBridge, RouteRequest};
 use crate::route_info::RouteInfo;
 use crate::YewRouterState;
 use log::{trace, warn};


### PR DESCRIPTION
It would be nice to get rid of the sender bridge and indirection agent soon.

Currently they are marked as deprecated, but once https://github.com/yewstack/yew/pull/639 lands, then a `RouteAgentDispatcher` could be created and the sender structs can be removed.