### PR TITLE
Alias state macro

### DIFF
--- a/crates/yew_router_macro/src/lib.rs
+++ b/crates/yew_router_macro/src/lib.rs
@@ -17,7 +17,7 @@ use route::route_impl;
 ///
 /// #### Simple
 /// ```
-/// use yew_router::{FromCaptures, matcher::{Captures, FromCaptures}};
+/// use yew_router::{FromCaptures, Captures};
 /// #[derive(FromCaptures)]
 /// struct Test {
 ///     value: String,
@@ -32,7 +32,7 @@ use route::route_impl;
 /// #### Option and Result
 /// ```
 ///# use std::num::ParseIntError;
-/// use yew_router::{FromCaptures, matcher::{Captures, FromCaptures}};
+/// use yew_router::{FromCaptures, Captures};
 /// #[derive(FromCaptures)]
 /// struct Test {
 ///     not_required: Option<String>,

--- a/crates/yew_router_route_parser/src/lib.rs
+++ b/crates/yew_router_route_parser/src/lib.rs
@@ -200,7 +200,8 @@ mod test {
                     field_name: "hello".to_string(),
                 })
                 .and_then(|m: &String| {
-                    String::try_from(m.clone()).map_err(|_| FromCapturesError::UnknownErr)
+                    String::try_from(m.clone())
+                        .map_err(|_| FromCapturesError::FailedParse { field_name: "hello".to_string(), source_string: m.to_string() })
                 })?;
 
             let there = captures
@@ -209,7 +210,8 @@ mod test {
                     field_name: "there".to_string(),
                 })
                 .and_then(|m: &String| {
-                    String::try_from(m.clone()).map_err(|_| FromCapturesError::UnknownErr)
+                    String::try_from(m.clone())
+                        .map_err(|_| FromCapturesError::FailedParse { field_name: "there".to_string(), source_string: m.to_string() })
                 })?;
 
             let x = TestStruct { hello, there };

--- a/examples/nested_routers/src/a_comp.rs
+++ b/examples/nested_routers/src/a_comp.rs
@@ -1,5 +1,5 @@
 use yew::prelude::*;
-use yew_router::render::component;
+use yew_router::component;
 use yew_router::route;
 use yew_router::{Route, Router};
 

--- a/examples/nested_routers/src/b_comp.rs
+++ b/examples/nested_routers/src/b_comp.rs
@@ -1,5 +1,5 @@
 use yew::prelude::*;
-use yew_router::render::component;
+use yew_router::component;
 use yew_router::route;
 use yew_router::{Route, Router};
 

--- a/examples/nested_routers/src/main.rs
+++ b/examples/nested_routers/src/main.rs
@@ -1,5 +1,5 @@
 use yew::{html, Component, ComponentLink, Html, Renderable, ShouldRender};
-use yew_router::{Router, Route, route, render::component};
+use yew_router::{Router, Route, route, component};
 use yew_router::components::RouterButton;
 use crate::page_not_found::PageNotFound;
 use crate::a_comp::AComp;

--- a/examples/routing_component/src/a_component.rs
+++ b/examples/routing_component/src/a_component.rs
@@ -2,7 +2,7 @@ use crate::c_component::CModel;
 use yew::prelude::*;
 use yew::Properties;
 use yew_router::components::router_button::RouterButton;
-use yew_router::render::component;
+use yew_router::component;
 use yew_router::route;
 use yew_router::FromCaptures;
 use yew_router::{Route, Router};

--- a/examples/routing_component/src/b_component.rs
+++ b/examples/routing_component/src/b_component.rs
@@ -2,8 +2,8 @@ use std::str::FromStr;
 use std::usize;
 use yew::prelude::*;
 use yew::Properties;
-use yew_router::matcher::{FromCaptures, Captures};
-use yew_router::matcher::FromCapturesError;
+use yew_router::{FromCaptures, Captures};
+use yew_router::FromCapturesError;
 use yew_router::route;
 use yew_router::agent::RouteRequest;
 use yew_router::{RouteAgent, RouteInfo};
@@ -143,7 +143,10 @@ impl FromCaptures for Props {
     fn from_captures(captures: &Captures) -> Result<Self, FromCapturesError> {
         let number = captures
             .get("number")
-            .map(|n: &String| usize::from_str(&n).map_err(|_| FromCapturesError::UnknownErr))
+            .map(|n: &String| {
+                usize::from_str(&n)
+                    .map_err(|_| FromCapturesError::FailedParse { field_name: "number".to_string(), source_string: n.to_string() })
+            })
             .transpose()?;
 
         let props = Props {

--- a/examples/routing_component/src/main.rs
+++ b/examples/routing_component/src/main.rs
@@ -14,8 +14,8 @@ use crate::b_component::BModel;
 use crate::c_component::CModel;
 
 use yew_router::matcher::Captures;
-use yew_router::render::component;
-use yew_router::render::render;
+use yew_router::component;
+use yew_router::render;
 
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;

--- a/yew_router/src/agent/mod.rs
+++ b/yew_router/src/agent/mod.rs
@@ -1,4 +1,7 @@
-//! Routing service
+//! Routing agent.
+//!
+//! It wraps a route service and allows calls to be sent to it to update every subscriber,
+//! or just the element that made the request.
 use crate::route_service::RouteService;
 
 use yew::prelude::worker::*;
@@ -16,10 +19,8 @@ use yew::callback::Callback;
 
 
 pub mod bridge;
-use bridge::RouteAgentBridge as RouteAgentBridgeImpl;
+use bridge::RouteAgentBridge;
 
-/// Alias to RouteAgentBridge<()>;
-pub type RouteAgentBridge = RouteAgentBridgeImpl<()>;
 
 
 /// Any state that can be used in the router agent must meet the criteria of this trait.
@@ -185,7 +186,7 @@ pub struct RouteSenderAgent<T>
             for<'de> T: RouterState<'de>,
 {
     /// This acts as a level of indirection.
-    router_agent: RouteAgentBridgeImpl<T>,
+    router_agent: RouteAgentBridge<T>,
 }
 
 impl<T: for<'de> RouterState<'de>> Debug for RouteSenderAgent<T> {
@@ -207,7 +208,7 @@ impl<T> Agent for RouteSenderAgent<T>
 
     fn create(link: AgentLink<Self>) -> Self {
         RouteSenderAgent {
-            router_agent: RouteAgentBridgeImpl::new(link.send_back(|_| ())),
+            router_agent: RouteAgentBridge::new(link.send_back(|_| ())),
         }
     }
 
@@ -233,8 +234,8 @@ impl<T: for<'de> RouterState<'de>> Debug for RouteSenderAgentBridge<T> {
 }
 
 impl<T> RouteSenderAgentBridge<T>
-    where
-            for<'de> T: RouterState<'de>,
+where
+        for<'de> T: RouterState<'de>,
 {
     /// Creates a new sender only bridge.
     pub fn new(callback: Callback<Void>) -> Self {

--- a/yew_router/src/alias.rs
+++ b/yew_router/src/alias.rs
@@ -1,0 +1,76 @@
+/// Generates a set of aliases to common structures within yew_router.
+///
+/// Because they should be the same across a given application,
+/// its a handy way to make sure that every type that could be needed is generated.
+#[macro_export]
+macro_rules! router_aliases {
+    ($StateT:ty) => {
+        router_aliases!($StateT, stringify!($StateT));
+    };
+    ($StateT:ty, $StateName:expr) => {
+        mod router_aliases {
+            use $crate::matcher::RenderFn;
+
+            #[doc = "Alias to [RouteInfo<"]
+            #[doc = $StateName]
+            #[doc = ">](route_info/struct.RouteInfo.html)."]
+            pub type RouteInfo = $crate::route_info::RouteInfo<$StateT>;
+
+            #[doc = "Alias to [RouteService<"]
+            #[doc = $StateName]
+            #[doc = ">](route_service/struct.RouteService.html)."]
+            pub type RouteService = $crate::route_service::RouteService<$StateT>;
+
+            #[cfg(feature="router_agent")]
+            #[doc = "Alias to [RouteAgent<"]
+            #[doc = $StateName]
+            #[doc = ">](agent/struct.RouteAgent.html)."]
+            pub type RouteAgent = $crate::agent::RouteAgent<$StateT>;
+
+            #[cfg(feature="router_agent")]
+            #[doc = "Alias to [RouteAgentBridge<"]
+            #[doc = $StateName]
+            #[doc = ">](agent/bridge/struct.RouteAgentBridge.html)`."]
+            pub type RouteAgentBridge = $crate::agent::bridge::RouteAgentBridge<$StateT>;
+
+            #[cfg(feature="router")]
+            #[doc = "Alias to [Router<"]
+            #[doc = $StateName]
+            #[doc = ">](router_component/router/struct.Router.html)."]
+            pub type Router = $crate::router_component::router::Router<$StateT>;
+
+            #[cfg(feature="router")]
+            #[doc = "Alias to [Route<"]
+            #[doc = $StateName]
+            #[doc = ">](router_component/route/struct.Route.html)."]
+            pub type Route = $crate::router_component::route::Route<$StateT>;
+
+            #[cfg(feature="router")]
+            #[doc = "Alias to [Render<"]
+            #[doc = $StateName]
+            #[doc = ">](router_component/render/struct.Render.html)."]
+            pub type Render = $crate::router_component::render::Render<$StateT>;
+
+            #[cfg(feature="router")]
+            #[doc = "Renders the provided closure in terms of a `Router<"]
+            #[doc = $StateName]
+            #[doc = ">`"]
+            pub fn render(render: impl RenderFn<Router> + 'static) -> $crate::router_component::render::Render<$StateT> {
+                $crate::router_component::render::render_s(render)
+            }
+
+            #[cfg(feature="router")]
+            #[doc = "Creates a components using a Html block in terms of a `Router<"]
+            #[doc = $StateName]
+            #[doc = ">`"]
+            pub fn component<T>() -> $crate::router_component::render::Render<$StateT>
+            where
+                T: yew::Component + yew::Renderable<T>,
+                <T as yew::Component>::Properties: crate::matcher::FromCaptures,
+            {
+                $crate::router_component::render::component_s::<T, $StateT>()
+            }
+        }
+    }
+}
+

--- a/yew_router/src/alias.rs
+++ b/yew_router/src/alias.rs
@@ -1,15 +1,25 @@
-/// Generates a set of aliases to common structures within yew_router.
+/// Generates a set of aliases to common structures within yew_router as well as functions
+/// for rendering routes.
 ///
 /// Because they should be the same across a given application,
 /// its a handy way to make sure that every type that could be needed is generated.
+///
+/// This macro is used to generate aliases and functions for the state type of `()` within yew_router.
+/// Instead of doing these yourself, use this macro if you need to store state in the browser.
+///
+/// # Example
+/// ```
+///# #[macro_use] extern crate yew_router;
+/// define_router_state!(Option<String>);
+///# fn main() {}
+/// ```
 #[macro_export]
-macro_rules! router_aliases {
+macro_rules! define_router_state {
     ($StateT:ty) => {
-        router_aliases!($StateT, stringify!($StateT));
+        define_router_state!($StateT, stringify!($StateT));
     };
     ($StateT:ty, $StateName:expr) => {
         mod router_aliases {
-            use $crate::matcher::RenderFn;
 
             #[doc = "Alias to [RouteInfo<"]
             #[doc = $StateName]
@@ -37,38 +47,38 @@ macro_rules! router_aliases {
             #[doc = "Alias to [Router<"]
             #[doc = $StateName]
             #[doc = ">](router_component/router/struct.Router.html)."]
-            pub type Router = $crate::router_component::router::Router<$StateT>;
+            pub type Router = $crate::router::Router<$StateT>;
 
             #[cfg(feature="router")]
             #[doc = "Alias to [Route<"]
             #[doc = $StateName]
             #[doc = ">](router_component/route/struct.Route.html)."]
-            pub type Route = $crate::router_component::route::Route<$StateT>;
+            pub type Route = $crate::route::Route<$StateT>;
 
             #[cfg(feature="router")]
             #[doc = "Alias to [Render<"]
             #[doc = $StateName]
             #[doc = ">](router_component/render/struct.Render.html)."]
-            pub type Render = $crate::router_component::render::Render<$StateT>;
+            pub type Render = $crate::render::Render<$StateT>;
 
             #[cfg(feature="router")]
             #[doc = "Renders the provided closure in terms of a `Router<"]
             #[doc = $StateName]
-            #[doc = ">`"]
-            pub fn render(render: impl RenderFn<Router> + 'static) -> $crate::router_component::render::Render<$StateT> {
-                $crate::router_component::render::render_s(render)
+            #[doc = ">`."]
+            pub fn render(render: impl $crate::matcher::RenderFn<Router> + 'static) -> $crate::render::Render<$StateT> {
+                $crate::render::render(render)
             }
 
             #[cfg(feature="router")]
-            #[doc = "Creates a components using a Html block in terms of a `Router<"]
+            #[doc = "Creates components using a Html block in terms of a `Router<"]
             #[doc = $StateName]
-            #[doc = ">`"]
-            pub fn component<T>() -> $crate::router_component::render::Render<$StateT>
+            #[doc = ">`."]
+            pub fn component<T>() -> $crate::render::Render<$StateT>
             where
                 T: yew::Component + yew::Renderable<T>,
-                <T as yew::Component>::Properties: crate::matcher::FromCaptures,
+                <T as yew::Component>::Properties: $crate::matcher::FromCaptures,
             {
-                $crate::router_component::render::component_s::<T, $StateT>()
+                $crate::render::component::<T, $StateT>()
             }
         }
     }

--- a/yew_router/src/alias.rs
+++ b/yew_router/src/alias.rs
@@ -12,6 +12,7 @@
 /// ```
 ///# #[macro_use] extern crate yew_router;
 /// define_router_state!(Option<String>);
+/// use router_state::Route; // alias to Route<Option<String>>
 ///# fn main() {}
 /// ```
 #[macro_export]

--- a/yew_router/src/alias.rs
+++ b/yew_router/src/alias.rs
@@ -1,5 +1,6 @@
-/// Generates a set of aliases to common structures within yew_router as well as functions
-/// for rendering routes.
+/// Generates a module named `router_state` containing aliases to common structures within yew_router
+/// that deal with operating with RouteInfo and its state values as well as functions for
+/// rendering routes.
 ///
 /// Because they should be the same across a given application,
 /// its a handy way to make sure that every type that could be needed is generated.
@@ -19,7 +20,8 @@ macro_rules! define_router_state {
         define_router_state!($StateT, stringify!($StateT));
     };
     ($StateT:ty, $StateName:expr) => {
-        mod router_aliases {
+        #[doc = "A set of aliases to commonly used structures and functions used for routing."]
+        mod router_state {
 
             #[doc = "Alias to [RouteInfo<"]
             #[doc = $StateName]
@@ -73,6 +75,8 @@ macro_rules! define_router_state {
             #[doc = "Creates components using a Html block in terms of a `Router<"]
             #[doc = $StateName]
             #[doc = ">`."]
+            #[doc = "\n"]
+            #[doc = "Use a turbofish (`::<YourComponent>`) to indicate what component should be rendered."]
             pub fn component<T>() -> $crate::render::Render<$StateT>
             where
                 T: yew::Component + yew::Renderable<T>,

--- a/yew_router/src/lib.rs
+++ b/yew_router/src/lib.rs
@@ -50,17 +50,13 @@
 #![allow(deprecated)] // TODO remove me once dispatchers lands
 use proc_macro_hack::proc_macro_hack;
 
+mod alias;
 pub mod route_service;
 
 #[cfg(feature = "router_agent")]
 pub mod agent;
-#[cfg(feature = "router_agent")]
-/// Alias to [RouteAgent<()>](struct.RouteAgent.html).
-pub type RouteAgent = agent::RouteAgent<()>;
 
 pub mod route_info;
-/// Alias to [RouteInfo<()>](struct.RouteInfo.html).
-pub type RouteInfo = route_info::RouteInfo<()>;
 
 #[cfg(feature = "components")]
 pub mod components;
@@ -69,13 +65,19 @@ pub mod components;
 mod router_component;
 #[cfg(feature = "router")]
 pub use router_component::{
-    render, render::component, route, router, Render, Route, Router, YewRouterState,
+    render, route, router, YewRouterState,
 };
 
 
 
+// Use this alias to define a module containing type aliases.
+router_aliases!(());
+pub use router_aliases::*;
+
 #[cfg(any(feature = "matchers", feature= "router" ) )]
 pub mod matcher;
+#[cfg(any(feature = "matchers", feature= "router" ) )]
+pub use matcher::{MatcherProvider, Matcher, Captures, FromCaptures, FromCapturesError};
 
 
 #[cfg(feature = "matchers")]

--- a/yew_router/src/lib.rs
+++ b/yew_router/src/lib.rs
@@ -19,12 +19,10 @@
 //! As this behavior is uncommon, aliases using the unit type (`()`) are provided to remove the
 //! need to specify the storage type you likely aren't using.
 //!
-//! If you do indeed want to specify the data to be stored in the History API consider the following:
-//! * The aliased types are typically named the same as their implementations, but are importable from a module higher up the hierarchy. You will have to look around for them in the docs as they aren't reexported at the highest level like their respective aliases.
-//! * You should use the same state type parameter everywhere. Having different state types means multiple RouteAgents will be spawned and they will not communicate with routers of differing state types.
-//! * You probably want to wrap your type in an `Option` and alias your type to make specifying it easier.
-//! * There are varying, mostly undocumented, limits to the maximum size of objects you can store in the History API across different browsers (firefox appears to be the lowest bar at 640kb). Keeping this in mind for cross-browser compatibility is a must.
-//! * If you are building a large application, it is a good idea to alias all entities used from this crate to use your specific state type much like has already been done with `()`.
+//! If you want to store state using the history API it is recommended that you generate your own aliases using the `define_router_state` macro.
+//! Give it a typename, and it will generate a module containing aliases and functions useful for routing.
+//!
+//!
 //!
 //! ## Orphaning
 //! Currently it is possible to "orphan" components in Yew. This happens when a component doesn't display anymore,
@@ -72,7 +70,7 @@ pub use router_component::{
 
 // Use this alias to define a module containing type aliases.
 define_router_state!(());
-pub use router_aliases::*;
+pub use router_state::*;
 
 pub use alias::*;
 

--- a/yew_router/src/lib.rs
+++ b/yew_router/src/lib.rs
@@ -71,8 +71,10 @@ pub use router_component::{
 
 
 // Use this alias to define a module containing type aliases.
-router_aliases!(());
+define_router_state!(());
 pub use router_aliases::*;
+
+pub use alias::*;
 
 #[cfg(any(feature = "matchers", feature= "router" ) )]
 pub mod matcher;

--- a/yew_router/src/router_component/mod.rs
+++ b/yew_router/src/router_component/mod.rs
@@ -5,27 +5,6 @@ pub mod router;
 
 use crate::agent::RouterState;
 
-/// Alias to [Router<()>](struct.Router.html)
-///
-/// # Note
-/// Because most end users will not use the ability to store state,
-/// this alias is used to make the most common type of utilization of the router easier to type and read.
-pub type Router = router::Router<()>;
-
-/// Alias to [Route<()>](struct.Route.html)
-///
-/// # Note
-/// Because most end users will not use the ability to store state,
-/// this alias is used to make the most common type of utilization of route easier to type and read.
-pub type Route = route::Route<()>;
-
-/// Alias to [Render<()>](struct.Render.html)
-///
-/// # Note
-/// Because most end users will not use the ability to store state,
-/// this alias is used to make the most common type of utilization of render function wrappers easier to type and read.
-pub type Render = render::Render<()>;
-
 /// Any state that can be managed by the `Router` must meet the criteria of this trait.
 pub trait YewRouterState<'de>: RouterState<'de> + PartialEq {}
 

--- a/yew_router/src/router_component/render.rs
+++ b/yew_router/src/router_component/render.rs
@@ -35,18 +35,18 @@ where
 
 /// Creates a render that creates the specified component if its
 /// props can be created from the provided matches using `FromCaptures`.
-pub fn component<T>() -> Render<()>
-where
-    T: Component + Renderable<T>,
-    <T as Component>::Properties: FromCaptures,
-{
-    component_s::<T, ()>()
-}
+//pub fn component<T>() -> Render<()>
+//where
+//    T: Component + Renderable<T>,
+//    <T as Component>::Properties: FromCaptures,
+//{
+//    component_s::<T, ()>()
+//}
 
 /// Shorthand for [Render::new()](structs.Render.html#new).
-pub fn render(render: impl RenderFn<Router<()>> + 'static) -> Render<()> {
-    Render::new(render)
-}
+//pub fn render(render: impl RenderFn<Router<()>> + 'static) -> Render<()> {
+//    Render::new(render)
+//}
 
 /// Shorthand for [Render::new()](structs.Render.html#new).
 ///

--- a/yew_router/src/router_component/render.rs
+++ b/yew_router/src/router_component/render.rs
@@ -18,10 +18,7 @@ fn create_component<COMP: Component + Renderable<COMP>, CONTEXT: Component>(
 
 /// Creates a `Render` that creates the specified component if its
 /// props can be created from the provided matches using `FromCaptures`.
-///
-/// # Note
-/// Allows specification of the router type.
-pub fn component_s<T, U>() -> Render<U>
+pub fn component<T, U>() -> Render<U>
 where
     T: Component + Renderable<T>,
     <T as Component>::Properties: FromCaptures,
@@ -33,26 +30,8 @@ where
     })
 }
 
-/// Creates a render that creates the specified component if its
-/// props can be created from the provided matches using `FromCaptures`.
-//pub fn component<T>() -> Render<()>
-//where
-//    T: Component + Renderable<T>,
-//    <T as Component>::Properties: FromCaptures,
-//{
-//    component_s::<T, ()>()
-//}
-
 /// Shorthand for [Render::new()](structs.Render.html#new).
-//pub fn render(render: impl RenderFn<Router<()>> + 'static) -> Render<()> {
-//    Render::new(render)
-//}
-
-/// Shorthand for [Render::new()](structs.Render.html#new).
-///
-/// # Note
-///// Allows specification of the router type.
-pub fn render_s<T: for<'de> YewRouterState<'de>>(
+pub fn render<T: for<'de> YewRouterState<'de>>(
     render: impl RenderFn<Router<T>> + 'static,
 ) -> Render<T> {
     Render::new(render)

--- a/yew_router/src/router_component/route.rs
+++ b/yew_router/src/router_component/route.rs
@@ -6,7 +6,7 @@ use std::fmt::{Debug, Error as FmtError, Formatter};
 use yew::{Children, Component, ComponentLink, Properties, ShouldRender};
 use crate::matcher::Matcher;
 
-/// A nested component used inside of [Router](struct.Router.html) that can determine if a
+/// A nested component used inside of [Router](../router/struct.Router.html) that can determine if a
 /// sub-component can be rendered.
 #[derive(Debug)]
 pub struct Route<T: for<'de> YewRouterState<'de>> {

--- a/yew_router/src/router_component/router.rs
+++ b/yew_router/src/router_component/router.rs
@@ -23,7 +23,7 @@ use crate::matcher::RenderFn;
 /// # Example
 /// ```
 /// use yew::prelude::*;
-/// use yew_router::{Router, Route, route, render::component};
+/// use yew_router::{Router, Route, route, component};
 /// use yew_router::FromCaptures;
 ///
 /// pub struct AComponent {}


### PR DESCRIPTION
Adds a macro that allows you to define aliases to router parts.

This makes it easy to create a module that has aliases to the state you use.