### PR TITLE
Derive Switch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
     "crates/yew_router_macro",
     "examples/routing_component",
     "examples/guide",
-    "examples/nested_routers"
+    "examples/nested_routers",
+    "examples/switch"
 ]
 

--- a/crates/yew_router_macro/src/lib.rs
+++ b/crates/yew_router_macro/src/lib.rs
@@ -55,7 +55,6 @@ pub fn route(tokens: TokenStream) -> TokenStream {
     route_impl(tokens)
 }
 
-
 #[proc_macro_derive(Switch, attributes(to))]
 pub fn switch(tokens: TokenStream) -> TokenStream {
     crate::switch::switch_impl(tokens)

--- a/crates/yew_router_macro/src/lib.rs
+++ b/crates/yew_router_macro/src/lib.rs
@@ -56,7 +56,12 @@ pub fn route(tokens: TokenStream) -> TokenStream {
 }
 
 
-#[proc_macro_derive(Switch)]
+#[proc_macro_derive(Switch, attributes(to))]
 pub fn switch(tokens: TokenStream) -> TokenStream {
     crate::switch::switch_impl(tokens)
+}
+
+#[proc_macro_attribute]
+pub fn to(_: TokenStream, _: TokenStream) -> TokenStream {
+    TokenStream::new()
 }

--- a/crates/yew_router_macro/src/lib.rs
+++ b/crates/yew_router_macro/src/lib.rs
@@ -4,6 +4,7 @@ use proc_macro_hack::proc_macro_hack;
 
 mod from_captures;
 use from_captures::from_captures_impl;
+mod switch;
 
 mod route;
 use route::route_impl;
@@ -52,4 +53,10 @@ pub fn from_captures(tokens: TokenStream) -> TokenStream {
 #[proc_macro_hack]
 pub fn route(tokens: TokenStream) -> TokenStream {
     route_impl(tokens)
+}
+
+
+#[proc_macro_derive(Switch)]
+pub fn switch(tokens: TokenStream) -> TokenStream {
+    crate::switch::switch_impl(tokens)
 }

--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -162,7 +162,7 @@ fn generate_trait_impl(enum_ident: Ident, switch_variants: Vec<SwitchVariant>) -
             let build_from_captures = build_variant_from_captures(&enum_ident, ident, fields);
 
             quote! {
-                let matcher = ::yew_router::matcher::route_matcher::RouteMatcher::try_from(#route_string).expect("Invalid matcher");
+                let matcher = ::yew_router::matcher::route_matcher::RouteMatcher::try_from(#route_string).expect("Invalid matcher"); // TODO this doesn't give adequate diagnostics. Figure out how to parse the failed generation and give useful feedback.
                 #build_from_captures
             }
         })

--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -162,7 +162,8 @@ fn generate_trait_impl(enum_ident: Ident, switch_variants: Vec<SwitchVariant>) -
             let build_from_captures = build_variant_from_captures(&enum_ident, ident, fields);
 
             quote! {
-                let matcher = ::yew_router::matcher::route_matcher::RouteMatcher::try_from(#route_string).expect("Invalid matcher"); // TODO this doesn't give adequate diagnostics. Figure out how to parse the failed generation and give useful feedback.
+                let matcher = ::yew_router::matcher::route_matcher::RouteMatcher::try_from(#route_string)
+                    .expect("Invalid Matcher"); // TODO this doesn't give adequate diagnostics. Figure out how to parse the failed generation and give useful feedback.
                 #build_from_captures
             }
         })

--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -104,7 +104,7 @@ fn generate_trait_impl(enum_ident: Ident, switch_variants: Vec<SwitchVariant>) -
                     })
                     .collect();
 
-                quote!(
+                quote! {
                     let produce_variant = move || -> Option<#enum_ident> {
                         Some(
                             #enum_ident::#variant_ident{
@@ -115,9 +115,30 @@ fn generate_trait_impl(enum_ident: Ident, switch_variants: Vec<SwitchVariant>) -
                     if let Some(e) = produce_variant() {
                         return Some(e);
                     }
-                )
+                }
             }
-            Fields::Unnamed(_) => panic!("Tuple enums not supported for the moment."),
+            Fields::Unnamed(unnamed_fields) => {
+                // todo, I need a vecdeque/ or zip a vec of captured strings
+                let fields = unnamed_fields.unnamed.iter().map(|x: &Field|{
+//                    unimplemented!()
+                    1
+                });
+                quote! {
+                    let produce_variant = move || -> Option<#enum_ident> {
+                        Some(
+                            #enum_ident::#variant_ident(
+                                #(#fields),*
+                            )
+                        )
+                    };
+                    if let Some(e) = produce_variant() {
+                        return Some(e);
+                    }
+                };
+
+
+                panic!("Tuple enums not supported for the moment.")
+            },
             Fields::Unit => {
                 quote!{
                     return Some(#enum_ident::#variant_ident);

--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -171,9 +171,7 @@ fn generate_trait_impl(enum_ident: Ident, switch_variants: Vec<SwitchVariant>) -
 
             quote! {
                 let matcher = ::yew_router::matcher::route_matcher::RouteMatcher::try_from(#route_string).expect("Invalid matcher");
-//                if let Some(captures) = matcher.match_route_string(&route.to_string()) { // TODO, there needs to be a way to get an ordered captures map
                 #build_from_captures
-//                }
             }
         })
         .collect::<Vec<_>>();

--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -1,0 +1,148 @@
+use proc_macro::{TokenStream};
+use syn::token::Enum;
+use syn::{Data, DeriveInput, Ident, Variant, Attribute, Meta, MetaNameValue, Lit, Fields};
+use syn::parse_macro_input;
+use syn::punctuated::IntoIter;
+use quote::quote;
+use proc_macro2::TokenStream as TokenStream2;
+
+
+const ATTRIBUTE_TOKEN_STRING: &str = "to";
+
+pub fn switch_impl(input: TokenStream) -> TokenStream {
+    let input: DeriveInput = parse_macro_input!(input as DeriveInput);
+
+    let enum_ident: Ident = input.ident;
+
+    let variants: IntoIter<Variant> = match input.data {
+        Data::Struct(ds) => {
+            panic!("Deriving Switch not supported for Structs.")
+        }
+        Data::Enum(de) => {
+            de.variants.into_iter()
+        }
+        Data::Union(_du) => {
+            panic!("Deriving FromCaptures not supported for Unions.")
+        }
+    };
+
+    let switch_variants: Vec<SwitchVariant> = variants
+        .map(|variant: Variant| {
+            SwitchVariant {
+                route_string: get_route_string(variant.attrs),
+                ident: variant.ident,
+                fields: variant.fields
+            }
+        })
+        .collect();
+
+    generate_trait_impl(enum_ident, switch_variants)
+
+}
+
+/// Gets this section:
+/// `#[to = "/route/thing"]`
+/// `       ^^^^^^^^^^^^^^`
+/// After matching the "to".
+fn get_route_string(attributes: Vec<Attribute>) -> String {
+    attributes.iter()
+        .filter_map(|attr: &Attribute| attr.parse_meta().ok())
+        .filter_map(|meta: Meta| {
+           match meta {
+               Meta::NameValue(x) => Some(x),
+               _ => None,
+           }
+       })
+       .filter_map(|mnv: MetaNameValue| {
+           mnv.path.clone()
+               .get_ident()
+               .filter(|ident| ident.to_string() == ATTRIBUTE_TOKEN_STRING.to_string())
+               .map(move |_| {
+                   match mnv.lit {
+                       Lit::Str(s) => Some(s.value()),
+                       _ => None
+                   }
+               })
+               .flatten_stable()
+       })
+       .next()
+       .unwrap_or_else(|| panic!(r##"The Switch derive function expects all variants to be annotated with [{} = "/route/string"] "##, ATTRIBUTE_TOKEN_STRING))
+}
+
+
+pub struct SwitchVariant {
+    route_string: String,
+    ident: Ident,
+    fields: Fields
+}
+
+
+fn generate_trait_impl(enum_ident: Ident, switch_variants: Vec<SwitchVariant>) -> TokenStream {
+
+    let variant_matchers: Vec<TokenStream2> = switch_variants.into_iter()
+        .map(|sv| {
+            let SwitchVariant {
+                route_string, ident, fields
+            } = sv;
+            quote! {
+                let matcher = ::yew_router::matcher::route_matcher::RouteMatcher::try_from(#route_string).expect("Invalid matcher");
+                let matcher = Matcher::from(matcher);
+                if let Some(captures) = matcher.match_route_string(&route.to_string()) {
+                    unimplemented!()
+                    // TODO return enum instance;
+                    // TODO, this will require specific versions for each enum type: unit, struct, tuple.
+                }
+
+            }
+        })
+        .collect::<Vec<_>>();
+
+
+    let token_stream = quote! {
+        impl ::yew_router::switch::Switch for #enum_ident {
+            fn switch<T>(route: RouteInfo<T>) -> Self {
+                #(#variant_matchers)*
+            }
+        }
+    };
+    TokenStream::from(token_stream)
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+trait Flatten<T> {
+    /// Because flatten is a nightly feature. I'm making a new variant of the function here for stable use.
+    /// The naming is changed to avoid this getting clobbered when object_flattening 60258 is stabilized.
+    fn flatten_stable(self) -> Option<T>;
+}
+
+impl<T> Flatten<T> for Option<Option<T>> {
+    fn flatten_stable(self) -> Option<T> {
+        match self {
+            None => None,
+            Some(v) => v,
+        }
+    }
+}

--- a/crates/yew_router_route_parser/src/lib.rs
+++ b/crates/yew_router_route_parser/src/lib.rs
@@ -72,7 +72,7 @@ pub type Captures<'a> = HashMap<&'a str, String>;
 /// Used for constructing `Properties` from URL matches.
 pub trait FromCaptures: Sized {
     /// Produces the props from the hashmap.
-    /// It is expected that `TryFrom<String>` be implemented on all of the types contained within the props.
+    /// For deriving, it is expected that `TryFrom<String>` be implemented on all of the types contained within the props.
     fn from_captures(captures: &Captures) -> Result<Self, FromCapturesError>;
     /// Verifies that all of the field names produced by the PathMatcher exist on the target props.
     /// Should panic if not all match.

--- a/crates/yew_router_route_parser/src/lib.rs
+++ b/crates/yew_router_route_parser/src/lib.rs
@@ -295,5 +295,4 @@ mod test {
         let expected = "The field: 'lorem' was not present in your path matcher.";
         assert_eq!(displayed, expected);
     }
-
 }

--- a/crates/yew_router_route_parser/src/parser/core.rs
+++ b/crates/yew_router_route_parser/src/parser/core.rs
@@ -240,5 +240,4 @@ mod test {
     fn can_specify_exact_match_option() {
         capture("{(lorem|ipsum)}").expect("Should complete");
     }
-
 }

--- a/crates/yew_router_route_parser/src/parser/error.rs
+++ b/crates/yew_router_route_parser/src/parser/error.rs
@@ -381,7 +381,6 @@ mod test_conditions {
     fn dangling_query_avoids_false_positive_capture() {
         assert!(!dangling_query("?thing={}"))
     }
-
 }
 
 #[cfg(test)]
@@ -586,5 +585,4 @@ Message:         'Double slashes ('//') are not allowed.'"##;
         };
         assert_eq!(error, expected)
     }
-
 }

--- a/crates/yew_router_route_parser/src/parser/path.rs
+++ b/crates/yew_router_route_parser/src/parser/path.rs
@@ -278,5 +278,4 @@ mod test {
     fn option_section_can_start_matcher_string() {
         path_parser("[/lorem]").expect("Should validate");
     }
-
 }

--- a/crates/yew_router_route_parser/src/token_optimizer.rs
+++ b/crates/yew_router_route_parser/src/token_optimizer.rs
@@ -437,5 +437,4 @@ mod test {
         next_delimiters(tokens.iter().peekable())("/thing").expect("should match");
         next_delimiters(tokens.iter().peekable())("/thing/").expect("should match");
     }
-
 }

--- a/examples/guide/src/guide.rs
+++ b/examples/guide/src/guide.rs
@@ -102,7 +102,7 @@ impl Renderable<Guide> for Guide {
 
 fn render_page_list_item(props: PageProps, route: &RouteInfo) -> Html<Guide> {
     let pm: RouteMatcher = RouteMatcher::try_from(&props.page_url).unwrap();
-    if pm.match_route(&route.to_string()).is_ok() {
+    if pm.capture_route_into_map(&route.to_string()).is_ok() {
         log::debug!("Found an active");
         html! {
             <li style="padding-left: 4px; padding-right: 4px; padding-top: 6px; padding-bottom: 6px; background-color: lightgray;">

--- a/examples/switch/Cargo.toml
+++ b/examples/switch/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "switch"
+version = "0.1.0"
+authors = ["Henry Zimmerman <zimhen7@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+yew_router = {path = "../../"}

--- a/examples/switch/src/main.rs
+++ b/examples/switch/src/main.rs
@@ -1,10 +1,25 @@
 fn main() {
-    println!("Hello, world!");
+    let route = RouteInfo::<()>::from("/some/route");
+    let app_route = AppRoute::switch(route);
+    dbg!(app_route);
+
+    let route = RouteInfo::<()>::from("/some/other");
+    let app_route = AppRoute::switch(route);
+    dbg!(app_route);
+
+    let route = RouteInfo::<()>::from("/yeet");
+    let app_route = AppRoute::switch(route);
+    dbg!(app_route);
 }
 use yew_router::Switch;
+use yew_router::route_info::RouteInfo;
 
-#[derive(Switch)]
+#[derive(Switch, Debug)]
 pub enum AppRoute {
     #[to = "/some/route"]
-    SomeRoute
+    SomeRoute,
+    #[to = "/some/{thing}"]
+    Something {
+        thing: String
+    }
 }

--- a/examples/switch/src/main.rs
+++ b/examples/switch/src/main.rs
@@ -7,6 +7,10 @@ fn main() {
     let app_route = AppRoute::switch(route);
     dbg!(app_route);
 
+    let route = RouteInfo::<()>::from("/another/other");
+    let app_route = AppRoute::switch(route);
+    dbg!(app_route);
+
     let route = RouteInfo::<()>::from("/yeet");
     let app_route = AppRoute::switch(route);
     dbg!(app_route);
@@ -21,5 +25,7 @@ pub enum AppRoute {
     #[to = "/some/{thing}"]
     Something {
         thing: String
-    }
+    },
+    #[to = "/another/{thing}"]
+    Another(String)
 }

--- a/examples/switch/src/main.rs
+++ b/examples/switch/src/main.rs
@@ -1,0 +1,10 @@
+fn main() {
+    println!("Hello, world!");
+}
+use yew_router::Switch;
+
+#[derive(Switch)]
+pub enum AppRoute {
+    #[to = "/some/route"]
+    SomeRoute
+}

--- a/examples/switch/src/main.rs
+++ b/examples/switch/src/main.rs
@@ -15,17 +15,15 @@ fn main() {
     let app_route = AppRoute::switch(route);
     dbg!(app_route);
 }
-use yew_router::Switch;
 use yew_router::route_info::RouteInfo;
+use yew_router::Switch;
 
 #[derive(Switch, Debug)]
 pub enum AppRoute {
     #[to = "/some/route"]
     SomeRoute,
     #[to = "/some/{thing}"]
-    Something {
-        thing: String
-    },
+    Something { thing: String },
     #[to = "/another/{thing}"]
-    Another(String)
+    Another(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,6 @@ pub use crate::route_info::RouteState;
 #[cfg(feature = "router")]
 pub use crate::router::RouterState;
 
-
 mod switch;
 pub use switch::Switch;
 pub use yew_router_macro::Switch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,9 @@ pub use crate::route_info::RouteState;
 #[cfg(feature = "router")]
 pub use crate::router::RouterState;
 
+
+pub mod switch;
+
 /// The route macro produces a Matcher which can be used to determine if a route string should cause
 /// a section of html or component should render.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,9 @@ pub use crate::route_info::RouteState;
 pub use crate::router::RouterState;
 
 
-pub mod switch;
+mod switch;
+pub use switch::Switch;
+pub use yew_router_macro::Switch;
 
 /// The route macro produces a Matcher which can be used to determine if a route string should cause
 /// a section of html or component should render.

--- a/src/matcher/mod.rs
+++ b/src/matcher/mod.rs
@@ -1,7 +1,7 @@
 //! Logic for matching and capturing route strings.
 
 pub use yew_router_route_parser::{
-    Capture, CaptureVariant, Captures, FromCapturedKeyValue, FromCapturesError, MatcherToken,
+    Capture, CaptureVariant, Captures, FromCapturedKeyValue, FromCapturesError, MatcherToken, parser::YewRouterParseError
 };
 
 pub use yew_router_route_parser::FromCaptures;

--- a/src/matcher/mod.rs
+++ b/src/matcher/mod.rs
@@ -58,7 +58,10 @@ impl Matcher {
     pub fn match_route_string<'a, 'b: 'a>(&'b self, route_string: &'a str) -> Option<Captures<'a>> {
         match self {
             #[cfg(feature = "route_matcher")]
-            Matcher::RouteMatcher(matcher) => matcher.capture_route_into_map(route_string).map(|x| x.1).ok(),
+            Matcher::RouteMatcher(matcher) => matcher
+                .capture_route_into_map(route_string)
+                .map(|x| x.1)
+                .ok(),
             #[cfg(feature = "regex_matcher")]
             Matcher::RegexMatcher(regex) => regex.match_route_string(route_string),
             Matcher::CustomMatcher(matcher) => matcher.match_route_string(route_string),

--- a/src/matcher/mod.rs
+++ b/src/matcher/mod.rs
@@ -58,7 +58,7 @@ impl Matcher {
     pub fn match_route_string<'a, 'b: 'a>(&'b self, route_string: &'a str) -> Option<Captures<'a>> {
         match self {
             #[cfg(feature = "route_matcher")]
-            Matcher::RouteMatcher(matcher) => matcher.match_route(route_string).map(|x| x.1).ok(),
+            Matcher::RouteMatcher(matcher) => matcher.capture_route_into_map(route_string).map(|x| x.1).ok(),
             #[cfg(feature = "regex_matcher")]
             Matcher::RegexMatcher(regex) => regex.match_route_string(route_string),
             Matcher::CustomMatcher(matcher) => matcher.match_route_string(route_string),

--- a/src/matcher/route_matcher/match_paths.rs
+++ b/src/matcher/route_matcher/match_paths.rs
@@ -13,6 +13,44 @@ use std::slice::Iter;
 use yew_router_route_parser::parser::util::consume_until;
 use yew_router_route_parser::{CaptureVariant, MatcherToken};
 
+
+/// Allows abstracting over capturing into a HashMap (Captures) or a Vec.
+pub trait CaptureCollection<'a> {
+    fn new2() -> Self;
+    fn insert2(&mut self, key: &'a str, value: String);
+    fn extend2(&mut self, other: Self);
+}
+
+impl <'a> CaptureCollection<'a> for Captures<'a> {
+    fn new2() -> Self {
+        Captures::new()
+    }
+
+    fn insert2(&mut self, key: &'a str, value: String) {
+        self.insert(key, value);
+    }
+
+    fn extend2(&mut self, other: Self) {
+        self.extend(other)
+    }
+}
+
+impl <'a> CaptureCollection<'a> for Vec<(&'a str, String)> {
+    fn new2() -> Self {
+        Vec::new()
+    }
+
+    fn insert2(&mut self, key: &'a str, value: String) {
+        self.push((key, value))
+    }
+
+    fn extend2(&mut self, other: Self) {
+        self.extend(other)
+    }
+}
+
+
+
 #[allow(clippy::trivially_copy_pass_by_ref)]
 pub(super) fn match_path<'a, 'b: 'a>(
     tokens: &'b [MatcherToken],
@@ -21,17 +59,26 @@ pub(super) fn match_path<'a, 'b: 'a>(
     move |i: &str| match_path_impl(tokens, *settings, i)
 }
 
-/// TODO return a parser instead of the result so it can be made all_consuming.
-fn match_path_impl<'a, 'b: 'a>(
+#[allow(clippy::trivially_copy_pass_by_ref)]
+pub(super) fn match_path_list<'a, 'b: 'a>(
+    tokens: &'b [MatcherToken],
+    settings: &'b MatcherSettings,
+) -> impl Fn(&'a str) -> IResult<&'a str, Vec<(&'b str, String)>> {
+    move |i: &str| match_path_impl(tokens, *settings, i)
+}
+
+
+
+fn match_path_impl<'a, 'b: 'a, CAP: CaptureCollection<'b>>(
     tokens: &'b [MatcherToken],
     settings: MatcherSettings,
     mut i: &'a str,
-) -> IResult<&'a str, Captures<'b>> {
+) -> IResult<&'a str, CAP> {
     trace!("Attempting to match path: {:?} using: {:?}", i, tokens);
 
     let mut iter = tokens.iter().peekable();
 
-    let mut captures: Captures = Captures::new();
+    let mut captures: CAP = CAP::new2();
 
     while let Some(token) = iter.next() {
         i = match token {
@@ -43,7 +90,7 @@ fn match_path_impl<'a, 'b: 'a>(
                 match opt(|i| match_path_impl(&inner_tokens, settings, i))(i) {
                     Ok((ii, inner_captures)) => {
                         if let Some(inner_captures) = inner_captures {
-                            captures.extend(inner_captures);
+                            captures.extend2(inner_captures);
                         }
                         ii
                     }
@@ -57,7 +104,7 @@ fn match_path_impl<'a, 'b: 'a>(
                 CaptureVariant::ManyUnnamed => {
                     capture_many_unnamed(i, &mut iter, &capture.allowed_captures)?
                 }
-                CaptureVariant::NumberedUnnamed { sections } => capture_numbered_named(
+                CaptureVariant::NumberedUnnamed { sections } => capture_numbered_named::<CAP>(
                     i,
                     &mut iter,
                     None,
@@ -149,11 +196,11 @@ fn capture_many_unnamed<'a>(
     Ok(ii)
 }
 
-fn capture_named<'a, 'b>(
+fn capture_named<'a, 'b: 'a, CAP: CaptureCollection<'b>>(
     i: &'a str,
     iter: &mut Peekable<Iter<MatcherToken>>,
     capture_key: &'b str,
-    matches: &mut Captures<'b>,
+    matches: &mut CAP,
     allowed_captures: &Option<Vec<String>>,
 ) -> Result<&'a str, nom::Err<(&'a str, ErrorKind)>> {
     log::trace!("Matching Named ({})", capture_key);
@@ -163,23 +210,23 @@ fn capture_named<'a, 'b>(
             consume_until(delimiter),
             allowed_captures,
         )(i)?;
-        matches.insert(capture_key, captured);
+        matches.insert2(capture_key, captured);
         Ok(ii)
     } else {
         let (ii, captured) = optionally_check_if_parsed_is_allowed_capture(
             map(valid_capture_characters, String::from),
             allowed_captures,
         )(i)?;
-        matches.insert(capture_key, captured.to_string());
+        matches.insert2(capture_key, captured.to_string());
         Ok(ii)
     }
 }
 
-fn capture_many_named<'a, 'b>(
+fn capture_many_named<'a, 'b, CAP: CaptureCollection<'b>>(
     i: &'a str,
     iter: &mut Peekable<Iter<MatcherToken>>,
     capture_key: &'b str,
-    matches: &mut Captures<'b>,
+    matches: &mut CAP,
     allowed_captures: &Option<Vec<String>>,
 ) -> Result<&'a str, nom::Err<(&'a str, ErrorKind)>> {
     log::trace!("Matching NumberedUnnamed ({})", capture_key);
@@ -189,25 +236,25 @@ fn capture_many_named<'a, 'b>(
             consume_until(delimiter),
             allowed_captures,
         )(i)?;
-        matches.insert(&capture_key, captured);
+        matches.insert2(&capture_key, captured);
         Ok(ii)
     } else if i.is_empty() {
-        matches.insert(&capture_key, "".to_string()); // TODO Is this a thing I want?
+        matches.insert2(&capture_key, "".to_string()); // TODO Is this a thing I want?
         Ok(i) // Match even if nothing is left
     } else {
         let (ii, c) = optionally_check_if_parsed_is_allowed_capture(
             map(valid_many_capture_characters, String::from),
             allowed_captures,
         )(i)?;
-        matches.insert(&capture_key, c.to_string());
+        matches.insert2(&capture_key, c.to_string());
         Ok(ii)
     }
 }
 
-fn capture_numbered_named<'a, 'b>(
+fn capture_numbered_named<'a, 'b, CAP: CaptureCollection<'b>>(
     mut i: &'a str,
     iter: &mut Peekable<Iter<MatcherToken>>,
-    name_and_captures: Option<(&'b str, &mut Captures<'b>)>,
+    name_and_captures: Option<(&'b str, &mut CAP)>,
     mut sections: usize,
     allowed_captures: &Option<Vec<String>>,
 ) -> Result<&'a str, nom::Err<(&'a str, ErrorKind)>> {
@@ -250,7 +297,7 @@ fn capture_numbered_named<'a, 'b>(
     if let Some(allowed_captures) = allowed_captures {
         if allowed_captures.iter().any(|x| x == &captured) {
             if let Some((name, captures)) = name_and_captures {
-                captures.insert(&name, captured);
+                captures.insert2(&name, captured);
             }
             Ok(i)
         } else {
@@ -258,7 +305,7 @@ fn capture_numbered_named<'a, 'b>(
         }
     } else {
         if let Some((name, captures)) = name_and_captures {
-            captures.insert(&name, captured);
+            captures.insert2(&name, captured);
         }
         Ok(i)
     }

--- a/src/matcher/route_matcher/match_paths.rs
+++ b/src/matcher/route_matcher/match_paths.rs
@@ -13,7 +13,6 @@ use std::slice::Iter;
 use yew_router_route_parser::parser::util::consume_until;
 use yew_router_route_parser::{CaptureVariant, MatcherToken};
 
-
 /// Allows abstracting over capturing into a HashMap (Captures) or a Vec.
 pub trait CaptureCollection<'a> {
     fn new2() -> Self;
@@ -21,7 +20,7 @@ pub trait CaptureCollection<'a> {
     fn extend2(&mut self, other: Self);
 }
 
-impl <'a> CaptureCollection<'a> for Captures<'a> {
+impl<'a> CaptureCollection<'a> for Captures<'a> {
     fn new2() -> Self {
         Captures::new()
     }
@@ -35,7 +34,7 @@ impl <'a> CaptureCollection<'a> for Captures<'a> {
     }
 }
 
-impl <'a> CaptureCollection<'a> for Vec<(&'a str, String)> {
+impl<'a> CaptureCollection<'a> for Vec<(&'a str, String)> {
     fn new2() -> Self {
         Vec::new()
     }
@@ -48,8 +47,6 @@ impl <'a> CaptureCollection<'a> for Vec<(&'a str, String)> {
         self.extend(other)
     }
 }
-
-
 
 #[allow(clippy::trivially_copy_pass_by_ref)]
 pub(super) fn match_path<'a, 'b: 'a>(
@@ -66,8 +63,6 @@ pub(super) fn match_path_list<'a, 'b: 'a>(
 ) -> impl Fn(&'a str) -> IResult<&'a str, Vec<(&'b str, String)>> {
     move |i: &str| match_path_impl(tokens, *settings, i)
 }
-
-
 
 fn match_path_impl<'a, 'b: 'a, CAP: CaptureCollection<'b>>(
     tokens: &'b [MatcherToken],

--- a/src/matcher/route_matcher/mod.rs
+++ b/src/matcher/route_matcher/mod.rs
@@ -13,6 +13,7 @@ use nom::combinator::all_consuming;
 use nom::IResult;
 use std::collections::HashSet;
 use yew_router_route_parser::{optimize_tokens, parser};
+use crate::matcher::YewRouterParseError;
 
 /// Attempts to match routes, transform the route to Component props and render that Component.
 ///
@@ -48,9 +49,8 @@ impl Default for MatcherSettings {
 
 impl RouteMatcher {
     /// Attempt to create a PathMatcher from a "matcher string".
-    pub fn try_from(i: &str) -> Result<Self, ()> // TODO: Error handling
-        where {
-        let tokens = parser::parse(i).map_err(|_| ())?;
+    pub fn try_from(i: &str) -> Result<Self, YewRouterParseError> {
+        let tokens = parser::parse(i)?;
         let settings = MatcherSettings::default();
         let pm = RouteMatcher {
             tokens: optimize_tokens(tokens, !settings.strict),

--- a/src/matcher/route_matcher/mod.rs
+++ b/src/matcher/route_matcher/mod.rs
@@ -61,7 +61,10 @@ impl RouteMatcher {
 
     // TODO see if more error handling can be done here.
     /// Match a route string, collecting the results into a map.
-    pub fn capture_route_into_map<'a, 'b: 'a>(&'b self, i: &'a str) -> IResult<&'a str, Captures<'a>> {
+    pub fn capture_route_into_map<'a, 'b: 'a>(
+        &'b self,
+        i: &'a str,
+    ) -> IResult<&'a str, Captures<'a>> {
         if self.settings.complete {
             all_consuming(match_paths::match_path(&self.tokens, &self.settings))(i)
         } else {
@@ -69,9 +72,11 @@ impl RouteMatcher {
         }
     }
 
-
     /// Match a route string, collecting the results into a vector.
-    pub fn capture_route_into_vec<'a, 'b: 'a>(&'b self, i: &'a str) -> IResult<&'a str, Vec<(&'b str, String)>> {
+    pub fn capture_route_into_vec<'a, 'b: 'a>(
+        &'b self,
+        i: &'a str,
+    ) -> IResult<&'a str, Vec<(&'b str, String)>> {
         if self.settings.complete {
             all_consuming(match_paths::match_path_list(&self.tokens, &self.settings))(i)
         } else {
@@ -144,7 +149,9 @@ mod tests {
     fn basic_separator() {
         let tokens = vec![RouteParserToken::Separator];
         let path_matcher = RouteMatcher::from(tokens);
-        path_matcher.capture_route_into_map("/").expect("should parse");
+        path_matcher
+            .capture_route_into_map("/")
+            .expect("should parse");
     }
 
     #[test]
@@ -156,7 +163,9 @@ mod tests {
         ];
 
         let path_matcher = RouteMatcher::from(tokens);
-        path_matcher.capture_route_into_map("/lorem/").expect("should parse");
+        path_matcher
+            .capture_route_into_map("/lorem/")
+            .expect("should parse");
     }
 
     #[test]
@@ -167,7 +176,9 @@ mod tests {
             RouteParserToken::Separator,
         ];
         let path_matcher = RouteMatcher::from(tokens);
-        let (_, matches) = path_matcher.capture_route_into_map("/ipsum/").expect("should parse");
+        let (_, matches) = path_matcher
+            .capture_route_into_map("/ipsum/")
+            .expect("should parse");
         assert_eq!(matches["lorem"], "ipsum".to_string())
     }
 
@@ -178,7 +189,9 @@ mod tests {
             RouteParserToken::Capture(Capture::from(CaptureVariant::Named("lorem".to_string()))),
         ];
         let path_matcher = RouteMatcher::from(tokens);
-        let (_, matches) = path_matcher.capture_route_into_map("/ipsum").expect("should parse");
+        let (_, matches) = path_matcher
+            .capture_route_into_map("/ipsum")
+            .expect("should parse");
         assert_eq!(matches["lorem"], "ipsum".to_string())
     }
 
@@ -191,7 +204,9 @@ mod tests {
             RouteParserToken::Capture(Capture::from(CaptureVariant::Unnamed)),
         ];
         let path_matcher = RouteMatcher::from(tokens);
-        let (_, _matches) = path_matcher.capture_route_into_map("/a/").expect("should parse");
+        let (_, _matches) = path_matcher
+            .capture_route_into_map("/a/")
+            .expect("should parse");
     }
 
     #[test]
@@ -279,5 +294,4 @@ mod tests {
             "garbage1/garbage2/garbage3".to_string()
         )
     }
-
 }

--- a/src/matcher/route_matcher/mod.rs
+++ b/src/matcher/route_matcher/mod.rs
@@ -61,7 +61,7 @@ impl RouteMatcher {
 
     // TODO see if more error handling can be done here.
     /// Match a route string, collecting the results into a map.
-    pub fn match_route<'a, 'b: 'a>(&'b self, i: &'a str) -> IResult<&'a str, Captures<'a>> {
+    pub fn capture_route_into_map<'a, 'b: 'a>(&'b self, i: &'a str) -> IResult<&'a str, Captures<'a>> {
         if self.settings.complete {
             all_consuming(match_paths::match_path(&self.tokens, &self.settings))(i)
         } else {
@@ -71,7 +71,7 @@ impl RouteMatcher {
 
 
     /// Match a route string, collecting the results into a vector.
-    pub fn capture_route_into_list<'a, 'b: 'a>(&'b self, i: &'a str) -> IResult<&'a str, Vec<(&'b str, String)>> {
+    pub fn capture_route_into_vec<'a, 'b: 'a>(&'b self, i: &'a str) -> IResult<&'a str, Vec<(&'b str, String)>> {
         if self.settings.complete {
             all_consuming(match_paths::match_path_list(&self.tokens, &self.settings))(i)
         } else {
@@ -144,7 +144,7 @@ mod tests {
     fn basic_separator() {
         let tokens = vec![RouteParserToken::Separator];
         let path_matcher = RouteMatcher::from(tokens);
-        path_matcher.match_route("/").expect("should parse");
+        path_matcher.capture_route_into_map("/").expect("should parse");
     }
 
     #[test]
@@ -156,7 +156,7 @@ mod tests {
         ];
 
         let path_matcher = RouteMatcher::from(tokens);
-        path_matcher.match_route("/lorem/").expect("should parse");
+        path_matcher.capture_route_into_map("/lorem/").expect("should parse");
     }
 
     #[test]
@@ -167,7 +167,7 @@ mod tests {
             RouteParserToken::Separator,
         ];
         let path_matcher = RouteMatcher::from(tokens);
-        let (_, matches) = path_matcher.match_route("/ipsum/").expect("should parse");
+        let (_, matches) = path_matcher.capture_route_into_map("/ipsum/").expect("should parse");
         assert_eq!(matches["lorem"], "ipsum".to_string())
     }
 
@@ -178,7 +178,7 @@ mod tests {
             RouteParserToken::Capture(Capture::from(CaptureVariant::Named("lorem".to_string()))),
         ];
         let path_matcher = RouteMatcher::from(tokens);
-        let (_, matches) = path_matcher.match_route("/ipsum").expect("should parse");
+        let (_, matches) = path_matcher.capture_route_into_map("/ipsum").expect("should parse");
         assert_eq!(matches["lorem"], "ipsum".to_string())
     }
 
@@ -191,7 +191,7 @@ mod tests {
             RouteParserToken::Capture(Capture::from(CaptureVariant::Unnamed)),
         ];
         let path_matcher = RouteMatcher::from(tokens);
-        let (_, _matches) = path_matcher.match_route("/a/").expect("should parse");
+        let (_, _matches) = path_matcher.capture_route_into_map("/a/").expect("should parse");
     }
 
     #[test]
@@ -206,7 +206,7 @@ mod tests {
         ];
         let path_matcher = RouteMatcher::from(tokens);
         let (_, _matches) = path_matcher
-            .match_route("/garbage1/garbage2/garbage3/a")
+            .capture_route_into_map("/garbage1/garbage2/garbage3/a")
             .expect("should parse");
     }
 
@@ -220,7 +220,7 @@ mod tests {
         ];
         let path_matcher = RouteMatcher::from(tokens);
         let (s, _matches) = path_matcher
-            .match_route("/garbage1/garbage2/garbage3")
+            .capture_route_into_map("/garbage1/garbage2/garbage3")
             .expect("should parse");
         assert_eq!(s.len(), 0)
     }
@@ -238,7 +238,7 @@ mod tests {
         ];
         let path_matcher = RouteMatcher::from(tokens);
         let (_, matches) = path_matcher
-            .match_route("/garbage1/garbage2/garbage3/a")
+            .capture_route_into_map("/garbage1/garbage2/garbage3/a")
             .expect("should parse");
         assert_eq!(
             matches["captured"],
@@ -256,7 +256,7 @@ mod tests {
         ];
         let path_matcher = RouteMatcher::from(tokens);
         let (_, _matches) = path_matcher
-            .match_route("/garbage1/garbage2/garbage3/a")
+            .capture_route_into_map("/garbage1/garbage2/garbage3/a")
             .expect("should parse");
     }
 
@@ -272,7 +272,7 @@ mod tests {
         ];
         let path_matcher = RouteMatcher::from(tokens);
         let (_, matches) = path_matcher
-            .match_route("/garbage1/garbage2/garbage3/a")
+            .capture_route_into_map("/garbage1/garbage2/garbage3/a")
             .expect("should parse");
         assert_eq!(
             matches["captured"],

--- a/src/matcher/route_matcher/mod.rs
+++ b/src/matcher/route_matcher/mod.rs
@@ -60,13 +60,22 @@ impl RouteMatcher {
     }
 
     // TODO see if more error handling can be done here.
-
-    /// Match a route string.
+    /// Match a route string, collecting the results into a map.
     pub fn match_route<'a, 'b: 'a>(&'b self, i: &'a str) -> IResult<&'a str, Captures<'a>> {
         if self.settings.complete {
             all_consuming(match_paths::match_path(&self.tokens, &self.settings))(i)
         } else {
             match_paths::match_path(&self.tokens, &self.settings)(i)
+        }
+    }
+
+
+    /// Match a route string, collecting the results into a vector.
+    pub fn capture_route_into_list<'a, 'b: 'a>(&'b self, i: &'a str) -> IResult<&'a str, Vec<(&'b str, String)>> {
+        if self.settings.complete {
+            all_consuming(match_paths::match_path_list(&self.tokens, &self.settings))(i)
+        } else {
+            match_paths::match_path_list(&self.tokens, &self.settings)(i)
         }
     }
 

--- a/src/matcher/route_matcher/util.rs
+++ b/src/matcher/route_matcher/util.rs
@@ -33,5 +33,4 @@ mod test {
         parser("lorem").expect("Should match");
         parser("LoREm").expect("Should match");
     }
-
 }

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -24,11 +24,10 @@ use crate::route_info::RouteInfo;
 /// assert_eq!(TestEnum::switch(RouteInfo::<()>::from("/test/route")), Some(TestEnum::TestRoute));
 /// assert_eq!(TestEnum::switch(RouteInfo::<()>::from("/capture/string/lorem")), Some(TestEnum::CaptureString{path: "lorem".to_string()}));
 /// assert_eq!(TestEnum::switch(RouteInfo::<()>::from("/capture/number/22")), Some(TestEnum::CaptureNumber{num: 22}));
-///  assert_eq!(TestEnum::switch(RouteInfo::<()>::from("/capture/unnamed/lorem")), Some(TestEnum::CaptureUnnamed("lorem".to_string())));
+/// assert_eq!(TestEnum::switch(RouteInfo::<()>::from("/capture/unnamed/lorem")), Some(TestEnum::CaptureUnnamed("lorem".to_string())));
 /// ```
 ///
 pub trait Switch: Sized {
     /// Based on a route, possibly produce an itself.
     fn switch<T>(route: RouteInfo<T>) -> Option<Self>;
 }
-

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -1,5 +1,8 @@
+//! Route based on enums.
 use crate::route_info::RouteInfo;
 
-pub trait Switch {
+/// Routing trait for enums
+pub trait Switch: Sized {
+    /// Based on a route, possibly produce an itself.
     fn switch<T>(route: RouteInfo<T>) -> Option<Self>;
 }

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -1,0 +1,5 @@
+use crate::route_info::RouteInfo;
+
+pub trait Switch {
+    fn switch<T>(route: RouteInfo<T>) -> Option<Self>;
+}

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -2,7 +2,33 @@
 use crate::route_info::RouteInfo;
 
 /// Routing trait for enums
+///
+/// # Example
+/// ```
+/// use yew_router::Switch;
+/// use yew_router::route_info::RouteInfo;
+/// #[derive(Debug, Switch, PartialEq)]
+/// enum TestEnum {
+///     #[to = "/test/route"]
+///     TestRoute,
+///     #[to = "/capture/string/{path}"]
+///     CaptureString{path: String},
+///     #[to = "/capture/number/{num}"]
+///     CaptureNumber{num: usize},
+///     #[to = "/capture/unnamed/{doot}"] // TODO doesn't currently give out good diagnostics if the matching string is malformed.
+///     CaptureUnnamed(String),
+///     #[to = "{*}/skip/"]
+///     Skip
+/// }
+///
+/// assert_eq!(TestEnum::switch(RouteInfo::<()>::from("/test/route")), Some(TestEnum::TestRoute));
+/// assert_eq!(TestEnum::switch(RouteInfo::<()>::from("/capture/string/lorem")), Some(TestEnum::CaptureString{path: "lorem".to_string()}));
+/// assert_eq!(TestEnum::switch(RouteInfo::<()>::from("/capture/number/22")), Some(TestEnum::CaptureNumber{num: 22}));
+///  assert_eq!(TestEnum::switch(RouteInfo::<()>::from("/capture/unnamed/lorem")), Some(TestEnum::CaptureUnnamed("lorem".to_string())));
+/// ```
+///
 pub trait Switch: Sized {
     /// Based on a route, possibly produce an itself.
     fn switch<T>(route: RouteInfo<T>) -> Option<Self>;
 }
+

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -15,7 +15,7 @@ use crate::route_info::RouteInfo;
 ///     CaptureString{path: String},
 ///     #[to = "/capture/number/{num}"]
 ///     CaptureNumber{num: usize},
-///     #[to = "/capture/unnamed/{doot}"] // TODO doesn't currently give out good diagnostics if the matching string is malformed.
+///     #[to = "/capture/unnamed/{doot}"]
 ///     CaptureUnnamed(String),
 ///     #[to = "{*}/skip/"]
 ///     Skip


### PR DESCRIPTION
closes https://github.com/yewstack/yew_router/issues/80

Allows deriving a macro-like structure on enums that allows resolving one of the enum's variants from a route.