### PR TITLE
Simplify RouteInfo

### DIFF
--- a/src/components/router_button.rs
+++ b/src/components/router_button.rs
@@ -1,6 +1,6 @@
 //! A component wrapping a `<button>` tag that changes the route.
 use crate::agent::{RouteRequest, RouteSenderBridge, Void};
-use crate::route_info::{RouteInfo, RouteString};
+use crate::route_info::{RouteInfo};
 use yew::prelude::*;
 
 use super::Msg;
@@ -29,7 +29,7 @@ impl Component for RouterButton {
             Msg::NoOp => false,
             Msg::Clicked => {
                 let route_info = RouteInfo {
-                    route: RouteString::Unstructured(self.props.link.clone()),
+                    route: self.props.link.clone(),
                     state: self.props.state,
                 };
                 self.router.send(RouteRequest::ChangeRoute(route_info));

--- a/src/components/router_link.rs
+++ b/src/components/router_link.rs
@@ -1,6 +1,6 @@
 //! A component wrapping an `<a>` tag that changes the route.
 use crate::agent::{RouteRequest, RouteSenderBridge, Void};
-use crate::route_info::{RouteInfo, RouteString};
+use crate::route_info::{RouteInfo};
 use yew::prelude::*;
 
 use super::Msg;
@@ -28,7 +28,7 @@ impl Component for RouterLink {
             Msg::NoOp => false,
             Msg::Clicked => {
                 let route_info = RouteInfo {
-                    route: RouteString::Unstructured(self.props.link.clone()),
+                    route: self.props.link.clone(),
                     state: self.props.state,
                 };
                 self.router.send(RouteRequest::ChangeRoute(route_info));

--- a/src/matcher/route_matcher/mod.rs
+++ b/src/matcher/route_matcher/mod.rs
@@ -10,7 +10,6 @@ mod util;
 use super::Captures;
 use super::Matcher;
 use crate::matcher::YewRouterParseError;
-use crate::matcher::YewRouterParseError;
 use nom::combinator::all_consuming;
 use nom::IResult;
 use std::collections::HashSet;

--- a/src/route_info.rs
+++ b/src/route_info.rs
@@ -8,41 +8,17 @@ use stdweb::Value;
 
 //use std::ops::Deref;
 use yew::agent::Transferable;
+use std::ops::Deref;
 
 /// Any state that can be stored by the History API must meet the criteria of this trait.
 pub trait RouteState: Clone + Default + JsSerialize + TryFrom<Value> + 'static {}
 impl<T> RouteState for T where T: Clone + Default + JsSerialize + TryFrom<Value> + 'static {}
 
-/// An abstraction over how the string for the router was created.
-///
-/// # Note
-/// This is unstable and may be removed pre 1.0
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum RouteString {
-    /// An unstructured route string.
-    Unstructured(String),
-    /// A structured route string.
-    Structured {
-        /// The path.
-        path: String,
-        /// The query
-        query: String,
-        /// The Fragment
-        fragment: String,
-    },
-}
-
-impl Default for RouteString {
-    fn default() -> Self {
-        RouteString::Unstructured(Default::default())
-    }
-}
-
 /// The representation of a route, segmented into different sections for easy access.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct RouteInfo<T> {
     /// The route string
-    pub route: RouteString,
+    pub route: String,
     /// The state
     pub state: Option<T>,
 }
@@ -68,71 +44,24 @@ impl<T> RouteInfo<T> {
     /// That is only provided via events.
     /// See [RouteService.register_callback](struct.RouteService.html#method.register_callback) to acquire state.
     pub fn current_route(route_service: &RouteService<T>) -> Self {
-        let path = route_service.get_path();
-        let query = route_service.get_query();
-        let fragment = route_service.get_fragment();
+        let route = route_service.get_route();
+        // TODO, should try to get the state using the history api once that is exposed through stdweb.
         RouteInfo {
-            route: RouteString::Structured {
-                path,
-                query,
-                fragment,
-            },
+            route,
             state: None,
         }
     }
 
     /// Returns a string representation of the route.
     pub fn to_string(&self) -> String {
-        match &self.route {
-            RouteString::Unstructured(s) => s.to_owned(),
-            RouteString::Structured {
-                path,
-                query,
-                fragment,
-            } => format_route_string(path, query, fragment),
-        }
-    }
-
-    /// Gets the path if the RouteInfo was constructed with a structured route string.
-    ///
-    /// # Note
-    /// This expects that all three already have their expected separators (?, #, etc)
-    pub fn get_path(&self) -> Option<&str> {
-        if let RouteString::Structured { path, .. } = &self.route {
-            Some(&path)
-        } else {
-            None
-        }
-    }
-
-    /// Gets the query if the RouteInfo was constructed with a structured route string.
-    ///
-    /// # Note
-    /// This expects that all three already have their expected separators (?, #, etc)
-    pub fn get_query(&self) -> Option<&str> {
-        if let RouteString::Structured { query, .. } = &self.route {
-            Some(&query)
-        } else {
-            None
-        }
-    }
-    /// Gets the fragment if the RouteInfo was constructed with a structured route string.
-    ///
-    /// # Note
-    /// This expects that all three already have their expected separators (?, #, etc)
-    pub fn get_fragment(&self) -> Option<&str> {
-        if let RouteString::Structured { fragment, .. } = &self.route {
-            Some(&fragment)
-        } else {
-            None
-        }
+        self.route.to_string()
     }
 }
 
 impl<T> From<String> for RouteInfo<T> {
     fn from(string: String) -> RouteInfo<T> {
         RouteInfo {
-            route: RouteString::Unstructured(string),
+            route: string,
             state: None,
         }
     }
@@ -141,11 +70,20 @@ impl<T> From<String> for RouteInfo<T> {
 impl<T> From<&str> for RouteInfo<T> {
     fn from(string: &str) -> RouteInfo<T> {
         RouteInfo {
-            route: RouteString::Unstructured(string.to_string()),
+            route: string.to_string(),
             state: None,
         }
     }
 }
+
+impl <T> Deref for RouteInfo<T> {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.route
+    }
+}
+
 
 //impl<T> Deref for RouteInfo<T> {
 //    type Target = str;

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -31,3 +31,5 @@ pub trait Switch: Sized {
     /// Based on a route, possibly produce an itself.
     fn switch<T>(route: RouteInfo<T>) -> Option<Self>;
 }
+
+


### PR DESCRIPTION
Make RouteInfo only contain an unstructured string.

This removes the option of being able to easily get the path, the query and fragment from a RouteInfo. Now a user will have to parse those out themselves.

This is done for the sake of keeping the library simple.

----
The broader logic being that constructing RouteInfos using strings is tedious using the structured approach, versus just passing a single string representing the whole route. With work incoming involving using RouteInfos to pass around parts of a route, it makes implementation of that feature easier. Fine-grained access might be added back later once the routing specification becomes more exact.