### PR TITLE
Make Render work with non reference Switch

### DIFF
--- a/crates/yew_router_macro/Cargo.toml
+++ b/crates/yew_router_macro/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-proc-macro-hack = "0.5.9"
 syn = "1.0.2"
 quote = "1.0.1"
 yew_router_route_parser = {path = "../yew_router_route_parser"}

--- a/crates/yew_router_macro/src/lib.rs
+++ b/crates/yew_router_macro/src/lib.rs
@@ -1,13 +1,9 @@
 extern crate proc_macro;
 use proc_macro::TokenStream;
-//use proc_macro_hack::proc_macro_hack;
 
 mod from_captures;
 use from_captures::from_captures_impl;
 mod switch;
-
-//mod route;
-//use route::route_impl;
 
 /// Derives `FromCaptures` for the specified struct.
 ///
@@ -50,11 +46,8 @@ pub fn from_captures(tokens: TokenStream) -> TokenStream {
     from_captures_impl(tokens)
 }
 
-//#[proc_macro_hack]
-//pub fn route(tokens: TokenStream) -> TokenStream {
-//    route_impl(tokens)
-//}
 
+/// Implements `Switch` trait based on attributes present on the struct or enum variants.
 #[proc_macro_derive(Switch, attributes(to, lit, cap, rest, query, frag))]
 pub fn switch(tokens: TokenStream) -> TokenStream {
     crate::switch::switch_impl(tokens)

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -4,4 +4,6 @@ This example shows how to use this library without any of the features turned on
 Without any features, you lack the `Router` component and `RouteAgent` and its associated bridges and dispatchers.
 This means that you must use the `RouteService` to interface with the browser to handle route changes.
 
+Removing the `Router` component means that you have to deal with the `RouteService` directly and propagate change route messages up to the component that contains the `RouteService`.
+
 The unit type aliases part of the prelude are not included without any features. You may want to turn that back for actual use.

--- a/examples/router_component/src/main.rs
+++ b/examples/router_component/src/main.rs
@@ -79,10 +79,10 @@ impl Renderable<Model> for Model {
                 </nav>
                 <div>
                     <Router<AppRoute, ()>
-                        render = Router::render(|switch: Option<&AppRoute>| {
+                        render = Router::render(|switch: Option<AppRoute>| {
                             match switch {
                                 Some(AppRoute::A(route)) => html!{<AModel route = route />},
-                                Some(AppRoute::B{sub_path, number}) => html!{<BModel sub_path=sub_path.clone(), number=number.clone()/>},
+                                Some(AppRoute::B{sub_path, number}) => html!{<BModel sub_path=sub_path, number=number/>},
                                 Some(AppRoute::C) => html!{<CModel />},
                                 Some(AppRoute::E(string)) => html!{format!("hello {}", string)},
                                 None => html!{"404"}

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -117,8 +117,8 @@ impl<T, M> From<M> for Msg<T, M> {
 
 // TODO consider removing the Option, and creating two different render functions - one for rendering the switch, and one for a 404 case.
 /// Render function definition
-pub trait RenderFn<CTX: Component, SW>: Fn(Option<&SW>) -> Html<CTX> {}
-impl<T, CTX: Component, SW> RenderFn<CTX, SW> for T where T: Fn(Option<&SW>) -> Html<CTX> {}
+pub trait RenderFn<CTX: Component, SW>: Fn(Option<SW>) -> Html<CTX> {}
+impl<T, CTX: Component, SW> RenderFn<CTX, SW> for T where T: Fn(Option<SW>) -> Html<CTX> {}
 /// Owned Render function.
 pub struct Render<T: for<'de> RouterState<'de>, SW: Switch + 'static, M: 'static>(
     pub(crate) Rc<dyn RenderFn<Router<T, SW, M>, SW>>,
@@ -203,6 +203,6 @@ impl<T: for<'de> RouterState<'de>, SW: Switch + 'static, M: 'static> Renderable<
 {
     fn view(&self) -> VNode<Self> {
         let switch = SW::switch(self.route.clone());
-        (&self.props.render.0)(switch.as_ref())
+        (&self.props.render.0)(switch)
     }
 }


### PR DESCRIPTION
The `RenderFn` was defined like:
```rust
 pub trait RenderFn<CTX: Component, SW>: Fn(Option<&SW>) -> Html<CTX> {} 
```
Now it no longer takes the real switched value instead of a reference:
```rust
 pub trait RenderFn<CTX: Component, SW>: Fn(Option<SW>) -> Html<CTX> {} 
```