### PR TITLE
Rework Switch

### DIFF
--- a/crates/yew_router_macro/src/lib.rs
+++ b/crates/yew_router_macro/src/lib.rs
@@ -3,7 +3,6 @@ use proc_macro::TokenStream;
 
 mod switch;
 
-
 /// Implements `Switch` trait based on attributes present on the struct or enum variants.
 #[proc_macro_derive(Switch, attributes(to, lit, cap, rest, query, frag))]
 pub fn switch(tokens: TokenStream) -> TokenStream {

--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -225,7 +225,7 @@ pub fn build_serializer_for_enum(switch_items: &[SwitchItem], enum_ident: &Ident
         });
     quote! {
         use ::std::fmt::Write as __Write; // TODO: is importing this here hygenic?
-        use ::yew_router::RouteItem as _; // TODO get rid of this boi, its polluting the whole namespace. That or get rid of the whole RouteItem concept. It doesn't have to be different than Switch.
+//        use ::yew_router::RouteItem as _; // TODO get rid of this boi, its polluting the whole namespace. That or get rid of the whole RouteItem concept. It doesn't have to be different than Switch.
         let mut state: Option<T> = None;
         match #match_item {
             #(#variants)*,

--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -4,13 +4,12 @@ use proc_macro::TokenStream;
 use syn::{parse_macro_input, Fields};
 //use syn::punctuated::IntoIter;
 use crate::switch::enum_impl::generate_enum_impl;
-use crate::switch::shadow::{ShadowMatcherToken, ShadowCapture, ShadowCaptureVariant};
+use crate::switch::shadow::{ShadowCapture, ShadowCaptureVariant, ShadowMatcherToken};
 use crate::switch::struct_impl::generate_struct_impl;
-use syn::export::TokenStream2;
-use syn::{Data, DeriveInput, Ident, Variant};
 use proc_macro2::Span;
 use quote::quote;
-
+use syn::export::TokenStream2;
+use syn::{Data, DeriveInput, Ident, Variant};
 
 mod attribute;
 mod enum_impl;
@@ -48,20 +47,25 @@ pub fn switch_impl(input: TokenStream) -> TokenStream {
             generate_struct_impl(switch_item)
         }
         Data::Enum(de) => {
-            let switch_variants = de.variants.into_iter().map(|variant: Variant| {
-                let mut encountered_query = false;
-                let matcher = AttrToken::convert_attributes_to_tokens(variant.attrs)
-                    .into_iter()
-                    .enumerate()
-                    .map(|(index, at)| at.into_shadow_matcher_tokens(index, &mut encountered_query))
-                    .flatten()
-                    .collect::<Vec<_>>();
-                SwitchItem {
-                    matcher,
-                    ident: variant.ident,
-                    fields: variant.fields,
-                }
-            })
+            let switch_variants = de
+                .variants
+                .into_iter()
+                .map(|variant: Variant| {
+                    let mut encountered_query = false;
+                    let matcher = AttrToken::convert_attributes_to_tokens(variant.attrs)
+                        .into_iter()
+                        .enumerate()
+                        .map(|(index, at)| {
+                            at.into_shadow_matcher_tokens(index, &mut encountered_query)
+                        })
+                        .flatten()
+                        .collect::<Vec<_>>();
+                    SwitchItem {
+                        matcher,
+                        ident: variant.ident,
+                        fields: variant.fields,
+                    }
+                })
                 .collect::<Vec<SwitchItem>>();
             generate_enum_impl(ident, switch_variants)
         }
@@ -101,29 +105,22 @@ fn build_matcher_from_tokens(tokens: &[ShadowMatcherToken]) -> TokenStream2 {
 // TODO remove this
 fn test() {
     enum TestEnum {
-        Var{s: String}
+        Var { s: String },
     }
-    let te = TestEnum::Var {s: "yeet".to_string()};
+    let te = TestEnum::Var {
+        s: "yeet".to_string(),
+    };
     let mut buf = String::new();
-//    if let TestEnum::Var {s} = te {
-//        state = state.or(s.build_route_section*&mut buf)
-//    }
+    //    if let TestEnum::Var {s} = te {
+    //        state = state.or(s.build_route_section*&mut buf)
+    //    }
 }
 
-
-
-
-
-
-
-
-
-pub (crate) enum FieldType {
+pub(crate) enum FieldType {
     Named,
-    Unnamed{index: usize},
-    Unit
+    Unnamed { index: usize },
+    Unit,
 }
-
 
 /// This assumes that the variant/struct has been destructured.
 fn write_for_token(token: &ShadowMatcherToken, naming_scheme: FieldType) -> TokenStream2 {
@@ -135,26 +132,36 @@ fn write_for_token(token: &ShadowMatcherToken, naming_scheme: FieldType) -> Toke
         }
         ShadowMatcherToken::Capture(capture) => {
             match naming_scheme {
-                FieldType::Named | FieldType::Unit => {
-                    match &capture.capture_variant {
-                        ShadowCaptureVariant::Unnamed => panic!("Unnamed sections not supported for writing"),
-                        ShadowCaptureVariant::ManyUnnamed => panic!("ManyUnnamed sections not supported for writing"),
-                        ShadowCaptureVariant::NumberedUnnamed { .. } => panic!("NumberedUnnamed sections not supported for writing"),
-                        ShadowCaptureVariant::Named(name)
-                        | ShadowCaptureVariant::ManyNamed(name)
-                        | ShadowCaptureVariant::NumberedNamed { name, .. } => {
-                            let name = Ident::new(&name, Span::call_site());
-                            quote! {
-                                state = state.or(#name.build_route_section(buf));
-                            }
-                        },
+                FieldType::Named | FieldType::Unit => match &capture.capture_variant {
+                    ShadowCaptureVariant::Unnamed => {
+                        panic!("Unnamed sections not supported for writing")
                     }
-                }
-                FieldType::Unnamed{index} => {
+                    ShadowCaptureVariant::ManyUnnamed => {
+                        panic!("ManyUnnamed sections not supported for writing")
+                    }
+                    ShadowCaptureVariant::NumberedUnnamed { .. } => {
+                        panic!("NumberedUnnamed sections not supported for writing")
+                    }
+                    ShadowCaptureVariant::Named(name)
+                    | ShadowCaptureVariant::ManyNamed(name)
+                    | ShadowCaptureVariant::NumberedNamed { name, .. } => {
+                        let name = Ident::new(&name, Span::call_site());
+                        quote! {
+                            state = state.or(#name.build_route_section(buf));
+                        }
+                    }
+                },
+                FieldType::Unnamed { index } => {
                     match &capture.capture_variant {
-                        ShadowCaptureVariant::Unnamed => panic!("Unnamed sections not supported for writing"),
-                        ShadowCaptureVariant::ManyUnnamed => panic!("ManyUnnamed sections not supported for writing"),
-                        ShadowCaptureVariant::NumberedUnnamed { .. } => panic!("NumberedUnnamed sections not supported for writing"),
+                        ShadowCaptureVariant::Unnamed => {
+                            panic!("Unnamed sections not supported for writing")
+                        }
+                        ShadowCaptureVariant::ManyUnnamed => {
+                            panic!("ManyUnnamed sections not supported for writing")
+                        }
+                        ShadowCaptureVariant::NumberedUnnamed { .. } => {
+                            panic!("NumberedUnnamed sections not supported for writing")
+                        }
                         ShadowCaptureVariant::Named(_)
                         | ShadowCaptureVariant::ManyNamed(_)
                         | ShadowCaptureVariant::NumberedNamed { .. } => {
@@ -163,74 +170,143 @@ fn write_for_token(token: &ShadowMatcherToken, naming_scheme: FieldType) -> Toke
                             quote! {
                                 state = state.or(#name.build_route_section(&mut buf)); // TODO, this needs type information in order not to clobber the namespace. I don't want to have to import RouteInfo.
                             }
-                        },
+                        }
                     }
                 }
             }
-
         }
-        ShadowMatcherToken::Optional(_) => {
-            panic!("Writing optional sections is not supported.")
-        }
+        ShadowMatcherToken::Optional(_) => panic!("Writing optional sections is not supported."),
     }
 }
 
-pub fn build_serializer_for_enum(switch_items: &[SwitchItem], enum_ident: &Ident, match_item: &Ident) -> TokenStream2 {
-    let variants = switch_items.iter()
-        .map(|switch_item: &SwitchItem| {
-            let SwitchItem {
-                matcher,
-                ident,
-                fields
-            } = switch_item;
-            match fields {
-                Fields::Named(fields_named) => {
-                    let field_names = fields_named.named.iter().filter_map(|named| named.ident.as_ref());
-                    let writers = matcher.iter().map(|token| write_for_token(token, FieldType::Named));
-                    quote! {
-                        #enum_ident::#ident{#(#field_names),*} => {
-                            #(#writers)*
-                        }
+/// The serializer makes up the body of `build_route_section`.
+pub fn build_serializer_for_enum(
+    switch_items: &[SwitchItem],
+    enum_ident: &Ident,
+    match_item: &Ident,
+) -> TokenStream2 {
+    let variants = switch_items.iter().map(|switch_item: &SwitchItem| {
+        let SwitchItem {
+            matcher,
+            ident,
+            fields,
+        } = switch_item;
+        match fields {
+            Fields::Named(fields_named) => {
+                let field_names = fields_named
+                    .named
+                    .iter()
+                    .filter_map(|named| named.ident.as_ref());
+                let writers = matcher
+                    .iter()
+                    .map(|token| write_for_token(token, FieldType::Named));
+                quote! {
+                    #enum_ident::#ident{#(#field_names),*} => {
+                        #(#writers)*
                     }
-                },
-                Fields::Unnamed(fields_unnamed) => {
-                    let field_names = fields_unnamed.unnamed.iter().enumerate().map(|(index, _)| unnamed_field_index_item(index));
-                    let mut item_count = 0;
-                    let writers = matcher.iter()
-                        .map(| token| {
-                            if let ShadowMatcherToken::Capture(_) = &token {
-                                let ts = write_for_token(token, FieldType::Unnamed {index: item_count});
-                                item_count += 1;
-                                ts
-                            } else {
-                                // Its either a literal, or something that will panic currently
-                                write_for_token(token, FieldType::Unit)
-                            }
-                        });
-                    quote! {
-                        #enum_ident::#ident(#(#field_names),*) => {
-                            #(#writers)*
-                        }
-                    }
-                },
-                Fields::Unit => {
-                    let writers = matcher.iter().map(|token| write_for_token(token, FieldType::Unit));
-                    quote! {
-                        #enum_ident::#ident => {
-                            #(#writers)*
-                        }
-                    }
-                },
+                }
             }
-        });
+            Fields::Unnamed(fields_unnamed) => {
+                let field_names = fields_unnamed
+                    .unnamed
+                    .iter()
+                    .enumerate()
+                    .map(|(index, _)| unnamed_field_index_item(index));
+                let mut item_count = 0;
+                let writers = matcher.iter().map(|token| {
+                    if let ShadowMatcherToken::Capture(_) = &token {
+                        let ts = write_for_token(token, FieldType::Unnamed { index: item_count });
+                        item_count += 1;
+                        ts
+                    } else {
+                        // Its either a literal, or something that will panic currently
+                        write_for_token(token, FieldType::Unit)
+                    }
+                });
+                quote! {
+                    #enum_ident::#ident(#(#field_names),*) => {
+                        #(#writers)*
+                    }
+                }
+            }
+            Fields::Unit => {
+                let writers = matcher
+                    .iter()
+                    .map(|token| write_for_token(token, FieldType::Unit));
+                quote! {
+                    #enum_ident::#ident => {
+                        #(#writers)*
+                    }
+                }
+            }
+        }
+    });
     quote! {
-        use ::std::fmt::Write as __Write; // TODO: is importing this here hygenic?
-//        use ::yew_router::RouteItem as _; // TODO get rid of this boi, its polluting the whole namespace. That or get rid of the whole RouteItem concept. It doesn't have to be different than Switch.
+        use ::std::fmt::Write as __Write; // TODO: is importing this here hygienic?
         let mut state: Option<T> = None;
         match #match_item {
             #(#variants)*,
         }
-        return None;
+        return state;
+    }
+}
+
+pub fn build_serializer_for_struct(switch_item: &SwitchItem, item: &Ident) -> TokenStream2 {
+    let SwitchItem {
+        matcher,
+        ident,
+        fields,
+    } = switch_item;
+    let destructor_and_writers = match fields {
+        Fields::Named(fields_named) => {
+            let field_names = fields_named
+                .named
+                .iter()
+                .filter_map(|named| named.ident.as_ref());
+            let writers = matcher
+                .iter()
+                .map(|token| write_for_token(token, FieldType::Named));
+            quote! {
+                let #ident{#(#field_names),*} = #item;
+                #(#writers)*
+            }
+        }
+        Fields::Unnamed(fields_unnamed) => {
+            let field_names = fields_unnamed
+                .unnamed
+                .iter()
+                .enumerate()
+                .map(|(index, _)| unnamed_field_index_item(index));
+            let mut item_count = 0;
+            let writers = matcher.iter().map(|token| {
+                if let ShadowMatcherToken::Capture(_) = &token {
+                    let ts = write_for_token(token, FieldType::Unnamed { index: item_count });
+                    item_count += 1;
+                    ts
+                } else {
+                    // Its either a literal, or something that will panic currently
+                    write_for_token(token, FieldType::Unit)
+                }
+            });
+            quote! {
+                let #ident(#(#field_names),*) = #item;
+                #(#writers)*
+            }
+        }
+        Fields::Unit => {
+            let writers = matcher
+                .iter()
+                .map(|token| write_for_token(token, FieldType::Unit));
+            quote! {
+                #(#writers)*
+            }
+        }
+    };
+    quote! {
+        use ::std::fmt::Write as __Write; // TODO: is importing this here hygienic?
+        let mut state: Option<T> = None;
+        #destructor_and_writers
+        return state;
     }
 }
 

--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -160,7 +160,7 @@ fn write_for_token(token: &ShadowMatcherToken, naming_scheme: FieldType) -> Toke
                         | ShadowCaptureVariant::NumberedNamed { .. } => {
                             let name = unnamed_field_index_item(index);
                             quote! {
-                                state = state.or(#name.build_route_section(&mut buf));
+                                state = state.or(#name.build_route_section(&mut buf)); // TODO, this needs type information in order not to clobber the namespace. I don't want to have to import RouteInfo.
                             }
                         },
                     }
@@ -224,7 +224,7 @@ pub fn build_serializer_for_enum(switch_items: &[SwitchItem], enum_ident: &Ident
         });
     quote! {
         use ::std::fmt::Write;
-        use ::yew_router::RouteItem;
+        use ::yew_router::RouteItem as _; // TODO get rid of this boi, its polluting the whole namespace. That or get rid of the whole RouteItem concept. It doesn't have to be different than Switch.
         let mut state: Option<T> = None;
         match #match_item {
             #(#variants)*,

--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -4,7 +4,7 @@ use proc_macro::TokenStream;
 use syn::{parse_macro_input, Fields};
 //use syn::punctuated::IntoIter;
 use crate::switch::enum_impl::generate_enum_impl;
-use crate::switch::shadow::{ShadowCapture, ShadowCaptureVariant, ShadowMatcherToken};
+use crate::switch::shadow::{ShadowCaptureVariant, ShadowMatcherToken};
 use crate::switch::struct_impl::generate_struct_impl;
 use proc_macro2::Span;
 use quote::quote;
@@ -102,20 +102,7 @@ fn build_matcher_from_tokens(tokens: &[ShadowMatcherToken]) -> TokenStream2 {
     }
 }
 
-// TODO remove this
-fn test() {
-    enum TestEnum {
-        Var { s: String },
-    }
-    let te = TestEnum::Var {
-        s: "yeet".to_string(),
-    };
-    let mut buf = String::new();
-    //    if let TestEnum::Var {s} = te {
-    //        state = state.or(s.build_route_section*&mut buf)
-    //    }
-}
-
+/// Enum indicating which sort of writer is needed.
 pub(crate) enum FieldType {
     Named,
     Unnamed { index: usize },
@@ -251,6 +238,7 @@ pub fn build_serializer_for_enum(
     }
 }
 
+
 pub fn build_serializer_for_struct(switch_item: &SwitchItem, item: &Ident) -> TokenStream2 {
     let SwitchItem {
         matcher,
@@ -310,7 +298,9 @@ pub fn build_serializer_for_struct(switch_item: &SwitchItem, item: &Ident) -> To
     }
 }
 
-/// Creates an ident used for destructuring
+/// Creates an ident used for destructuring unnamed fields.
+///
+/// There needs to be a unified way to "mangle" the unnamed fields so they can be destructured,
 fn unnamed_field_index_item(index: usize) -> Ident {
     Ident::new(&format!("__field_{}", index), Span::call_site())
 }

--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -159,6 +159,7 @@ fn write_for_token(token: &ShadowMatcherToken, naming_scheme: FieldType) -> Toke
                         | ShadowCaptureVariant::ManyNamed(_)
                         | ShadowCaptureVariant::NumberedNamed { .. } => {
                             let name = unnamed_field_index_item(index);
+                            // TODO this either needs to find type info from a ty passed in, or RouteInfo needs to be nixed.
                             quote! {
                                 state = state.or(#name.build_route_section(&mut buf)); // TODO, this needs type information in order not to clobber the namespace. I don't want to have to import RouteInfo.
                             }
@@ -223,7 +224,7 @@ pub fn build_serializer_for_enum(switch_items: &[SwitchItem], enum_ident: &Ident
             }
         });
     quote! {
-        use ::std::fmt::Write;
+        use ::std::fmt::Write as __Write; // TODO: is importing this here hygenic?
         use ::yew_router::RouteItem as _; // TODO get rid of this boi, its polluting the whole namespace. That or get rid of the whole RouteItem concept. It doesn't have to be different than Switch.
         let mut state: Option<T> = None;
         match #match_item {

--- a/crates/yew_router_macro/src/switch/enum_impl.rs
+++ b/crates/yew_router_macro/src/switch/enum_impl.rs
@@ -30,7 +30,7 @@ pub fn generate_enum_impl(
                             #field_name: {
                                 let (v, s) = match captures.remove(#key) {
                                     Some(value) => {
-                                        <#field_ty as ::yew_router::RouteItem>::from_route_part(
+                                        <#field_ty as ::yew_router::Switch>::from_route_part(
                                             ::yew_router::route::Route {
                                                 route: value,
                                                 state,
@@ -39,7 +39,7 @@ pub fn generate_enum_impl(
                                     }
                                     None => {
                                         (
-                                            <#field_ty as ::yew_router::RouteItem>::key_not_available(),
+                                            <#field_ty as ::yew_router::Switch>::key_not_available(),
                                             state,
                                         )
                                     }
@@ -90,7 +90,7 @@ pub fn generate_enum_impl(
                                 {
                                     let (v, s) = match drain.next() {
                                         Some((_key, value)) => {
-                                            <#field_ty as ::yew_router::RouteItem>::from_route_part(
+                                            <#field_ty as ::yew_router::Switch>::from_route_part(
                                                 ::yew_router::route::Route {
                                                     route: value,
                                                     state,
@@ -99,7 +99,7 @@ pub fn generate_enum_impl(
                                         },
                                         None => {
                                             (
-                                                <#field_ty as ::yew_router::RouteItem>::key_not_available(),
+                                                <#field_ty as ::yew_router::Switch>::key_not_available(),
                                                 state,
                                             )
                                         }

--- a/crates/yew_router_macro/src/switch/enum_impl.rs
+++ b/crates/yew_router_macro/src/switch/enum_impl.rs
@@ -57,14 +57,18 @@ pub fn generate_enum_impl(
 
                 quote! {
                     let mut state = if let Some(mut captures) = matcher.capture_route_into_map(&route_string).ok().map(|x| x.1) {
-                        let (val, state) = (
-                            Some(
-                                #enum_ident::#variant_ident{
-                                    #(#fields),*
-                                }
-                            ),
-                            state
-                        );
+                        let create_item = || {
+                             (
+                                Some(
+                                    #enum_ident::#variant_ident {
+                                        #(#fields),*
+                                    }
+                                ),
+                                state
+                            )
+                        };
+                        let (val, state) = create_item();
+
                         if val.is_some() {
                             return (val, state);
                         }
@@ -114,14 +118,17 @@ pub fn generate_enum_impl(
                     // TODO put an annotation here allowing unused muts.
                     let mut state = if let Some(mut captures) = matcher.capture_route_into_vec(&route_string).ok().map(|x| x.1) {
                         let mut drain = captures.drain(..);
-                        let (val, state) = (
-                            Some(
-                                #enum_ident::#variant_ident(
-                                    #(#fields),*
-                                )
-                            ),
-                            state
-                        );
+                        let create_item = || {
+                             (
+                                Some(
+                                    #enum_ident::#variant_ident(
+                                        #(#fields),*
+                                    )
+                                ),
+                                state
+                            )
+                        };
+                        let (val, state) = create_item();
                         if val.is_some() {
                             return (val, state);
                         }

--- a/crates/yew_router_macro/src/switch/enum_impl.rs
+++ b/crates/yew_router_macro/src/switch/enum_impl.rs
@@ -6,24 +6,69 @@ use syn::export::TokenStream2;
 use syn::{Field, Fields, Ident, Type};
 
 pub fn generate_enum_impl(enum_ident: Ident, switch_variants: Vec<SwitchItem>) -> TokenStream {
-    /// Once the 'captures' exists, attempt to populate the fields from the list of captures.
-    fn build_variant_from_captures(
-        enum_ident: &Ident,
-        variant_ident: &Ident,
-        fields: &Fields,
-    ) -> TokenStream2 {
-        match fields {
-            Fields::Named(named_fields) => {
-                let fields: Vec<TokenStream2> = named_fields.named.iter()
-                    .filter_map(|field: &Field| {
-                        let field_ty: &Type = &field.ty;
-                        field.ident.as_ref().map(|i: &Ident| {
-                            let key = i.to_string();
-                            (i, key, field_ty)
-                        })
+
+
+    let variant_matchers = switch_variants
+        .iter()
+        .map(|sv| {
+            let SwitchItem {
+                matcher,
+                ident,
+                fields,
+            } = sv;
+            let build_from_captures = build_variant_from_captures(&enum_ident, ident, fields);
+            let matcher = super::build_matcher_from_tokens(&matcher);
+
+            quote! {
+                #matcher
+                #build_from_captures
+            }
+        });
+//        .collect::<Vec<_>>();
+
+    let match_item = Ident::new("self", Span::call_site());
+    let serializer = build_serializer_for_enum(&switch_variants, &enum_ident, &match_item);
+
+    let token_stream = quote! {
+        impl ::yew_router::Switch for #enum_ident {
+            fn from_route_part<T: ::yew_router::route::RouteState>(route: ::yew_router::route::Route<T>) -> (Option<Self>, Option<T>) {
+                let mut state = route.state;
+                let route_string = route.route;
+                #(#variant_matchers)*
+
+                return (None, state)
+            }
+
+            fn build_route_section<T>(self, mut buf: &mut String) -> Option<T> {
+                //pseudo-code:
+                // For every field:
+                //    write!(route, "{}", self.#field)
+                // Return None for now, because marking routes isn't supported yet.
+                #serializer
+            }
+        }
+    };
+    TokenStream::from(token_stream)
+}
+
+/// Once the 'captures' exists, attempt to populate the fields from the list of captures.
+fn build_variant_from_captures(
+    enum_ident: &Ident,
+    variant_ident: &Ident,
+    fields: &Fields,
+) -> TokenStream2 {
+    match fields {
+        Fields::Named(named_fields) => {
+            let fields: Vec<TokenStream2> = named_fields.named.iter()
+                .filter_map(|field: &Field| {
+                    let field_ty: &Type = &field.ty;
+                    field.ident.as_ref().map(|i: &Ident| {
+                        let key = i.to_string();
+                        (i, key, field_ty)
                     })
-                    .map(|(field_name, key, field_ty): (&Ident, String, &Type)|{
-                        quote!{
+                })
+                .map(|(field_name, key, field_ty): (&Ident, String, &Type)|{
+                    quote!{
                             #field_name: {
                                 let (v, s) = match captures.remove(#key) {
                                     Some(value) => {
@@ -50,10 +95,10 @@ pub fn generate_enum_impl(enum_ident: Ident, switch_variants: Vec<SwitchItem>) -
                                 }
                             }
                         }
-                    })
-                    .collect();
+                })
+                .collect();
 
-                quote! {
+            quote! {
                     let mut state = if let Some(mut captures) = matcher.capture_route_into_map(&route_string).ok().map(|x| x.1) {
                         let create_item = || {
                              (
@@ -75,11 +120,11 @@ pub fn generate_enum_impl(enum_ident: Ident, switch_variants: Vec<SwitchItem>) -
                         state
                     };
                 }
-            }
-            Fields::Unnamed(unnamed_fields) => {
-                let fields = unnamed_fields.unnamed.iter().map(|f: &Field| {
-                    let field_ty = &f.ty;
-                    quote! {
+        }
+        Fields::Unnamed(unnamed_fields) => {
+            let fields = unnamed_fields.unnamed.iter().map(|f: &Field| {
+                let field_ty = &f.ty;
+                quote! {
                         {
                             let (v, s) = match drain.next() {
                                 Some((_key, value)) => {
@@ -106,9 +151,9 @@ pub fn generate_enum_impl(enum_ident: Ident, switch_variants: Vec<SwitchItem>) -
                             }
                         }
                     }
-                });
+            });
 
-                quote! {
+            quote! {
                     // TODO put an annotation here allowing unused muts.
                     let mut state = if let Some(mut captures) = matcher.capture_route_into_vec(&route_string).ok().map(|x| x.1) {
                         let mut drain = captures.drain(..);
@@ -131,58 +176,15 @@ pub fn generate_enum_impl(enum_ident: Ident, switch_variants: Vec<SwitchItem>) -
                         state
                     };
                 }
-            }
-            Fields::Unit => {
-                quote! {
+        }
+        Fields::Unit => {
+            quote! {
                     let mut state = if let Some(_captures) = matcher.capture_route_into_map(&route_string).ok().map(|x| x.1) {
                         return (Some(#enum_ident::#variant_ident), state);
                     } else {
                         state
                     };
                 }
-            }
         }
     }
-
-    let variant_matchers: Vec<TokenStream2> = switch_variants
-        .iter()
-        .map(|sv| {
-            let SwitchItem {
-                matcher,
-                ident,
-                fields,
-            } = sv;
-            let build_from_captures = build_variant_from_captures(&enum_ident, ident, fields);
-            let matcher = super::build_matcher_from_tokens(&matcher);
-
-            quote! {
-                #matcher
-                #build_from_captures
-            }
-        })
-        .collect::<Vec<_>>();
-
-    let match_item = Ident::new("self", Span::call_site());
-    let serializer = build_serializer_for_enum(&switch_variants, &enum_ident, &match_item);
-
-    let token_stream = quote! {
-        impl ::yew_router::Switch for #enum_ident {
-            fn from_route_part<T: ::yew_router::route::RouteState>(route: ::yew_router::route::Route<T>) -> (Option<Self>, Option<T>) {
-                let mut state = route.state;
-                let route_string = route.route;
-                #(#variant_matchers)*
-
-                return (None, state)
-            }
-
-            fn build_route_section<T>(self, mut buf: &mut String) -> Option<T> {
-                //pseudo-code:
-                // For every field:
-                //    write!(route, "{}", self.#field)
-                // Return None for now, because marking routes isn't supported yet.
-                #serializer
-            }
-        }
-    };
-    TokenStream::from(token_stream)
 }

--- a/crates/yew_router_macro/src/switch/struct_impl.rs
+++ b/crates/yew_router_macro/src/switch/struct_impl.rs
@@ -97,32 +97,32 @@ fn build_variant_from_captures(ident: &Ident, fields: Fields) -> TokenStream2 {
                     .map(| f: &Field| {
                         let field_ty = &f.ty;
                         quote! {
-                                {
-                                    let (v, s) = match drain.next() {
-                                        Some((_key, value)) => {
-                                            <#field_ty as ::yew_router::RouteItem>::from_route_part(
-                                                ::yew_router::route::Route {
-                                                    route: value,
-                                                    state,
-                                                }
-                                            )
-                                        },
-                                        None => {
-                                            (
-                                                <#field_ty as ::yew_router::RouteItem>::key_not_available(),
+                            {
+                                let (v, s) = match drain.next() {
+                                    Some((_key, value)) => {
+                                        <#field_ty as ::yew_router::RouteItem>::from_route_part(
+                                            ::yew_router::route::Route {
+                                                route: value,
                                                 state,
-                                            )
-                                        }
-                                    };
-                                    match v {
-                                        Some(val) => {
-                                            state = s; // Set state for the next var.
-                                            val
-                                        },
-                                        None => return (None, s) // Failed
+                                            }
+                                        )
+                                    },
+                                    None => {
+                                        (
+                                            <#field_ty as ::yew_router::RouteItem>::key_not_available(),
+                                            state,
+                                        )
                                     }
+                                };
+                                match v {
+                                    Some(val) => {
+                                        state = s; // Set state for the next var.
+                                        val
+                                    },
+                                    None => return (None, s) // Failed
                                 }
                             }
+                        }
                     });
 
 

--- a/crates/yew_router_macro/src/switch/struct_impl.rs
+++ b/crates/yew_router_macro/src/switch/struct_impl.rs
@@ -10,7 +10,7 @@ pub fn generate_struct_impl(item: SwitchItem) -> TokenStream {
         ident,
         fields,
     } = &item;
-    let build_from_captures = build_variant_from_captures(&ident, &fields);
+    let build_from_captures = build_struct_from_captures(&ident, &fields);
     let matcher = super::build_matcher_from_tokens(&matcher);
 
     let match_item = Ident::new("self", Span::call_site());
@@ -37,7 +37,7 @@ pub fn generate_struct_impl(item: SwitchItem) -> TokenStream {
     TokenStream::from(token_stream)
 }
 
-fn build_variant_from_captures(ident: &Ident, fields: &Fields) -> TokenStream2 {
+fn build_struct_from_captures(ident: &Ident, fields: &Fields) -> TokenStream2 {
     match fields {
         Fields::Named(named_fields) => {
             let fields: Vec<TokenStream2> = named_fields

--- a/crates/yew_router_macro/src/switch/struct_impl.rs
+++ b/crates/yew_router_macro/src/switch/struct_impl.rs
@@ -1,4 +1,4 @@
-use crate::switch::SwitchItem;
+use crate::switch::{SwitchItem};
 use proc_macro2::Ident;
 use quote::quote;
 use syn::export::{TokenStream, TokenStream2};
@@ -10,8 +10,8 @@ pub fn generate_struct_impl(item: SwitchItem) -> TokenStream {
         ident,
         fields,
     } = item;
-    let build_from_captures = build_variant_from_captures(&ident, fields);
-    let matcher = super::build_matcher_from_tokens(matcher);
+    let build_from_captures = build_variant_from_captures(&ident, &fields);
+    let matcher = super::build_matcher_from_tokens(&matcher);
 
     let token_stream = quote! {
         impl ::yew_router::Switch for #ident {
@@ -34,18 +34,18 @@ pub fn generate_struct_impl(item: SwitchItem) -> TokenStream {
     TokenStream::from(token_stream)
 }
 
-fn build_variant_from_captures(ident: &Ident, fields: Fields) -> TokenStream2 {
+fn build_variant_from_captures(ident: &Ident, fields: &Fields) -> TokenStream2 {
     match fields {
         Fields::Named(named_fields) => {
-            let fields: Vec<TokenStream2> = named_fields.named.into_iter()
-                .filter_map(|field: Field| {
-                    let field_ty: Type = field.ty;
-                    field.ident.map(|i| {
+            let fields: Vec<TokenStream2> = named_fields.named.iter()
+                .filter_map(|field: &Field| {
+                    let field_ty: &Type = &field.ty;
+                    field.ident.as_ref().map(|i| {
                         let key = i.to_string();
                         (i, key, field_ty)
                     })
                 })
-                .map(|(field_name, key, field_ty): (Ident, String, Type)|{
+                .map(|(field_name, key, field_ty): (&Ident, String, &Type)|{
                     quote!{
                         #field_name: {
                             let (v, s) = match captures.remove(#key) {

--- a/crates/yew_router_macro/src/switch/struct_impl.rs
+++ b/crates/yew_router_macro/src/switch/struct_impl.rs
@@ -77,8 +77,8 @@ fn build_variant_from_captures(ident: &Ident, fields: Fields) -> TokenStream2 {
                 .collect();
 
             return quote! {
-                let mut state = if let Some(mut captures) = matcher.capture_route_into_map(&route_string).ok().map(|x| x.1) {
-                    let (val, state) = (
+                if let Some(mut captures) = matcher.capture_route_into_map(&route_string).ok().map(|x| x.1) {
+                    return (
                         Some(
                             #ident {
                                 #(#fields),*
@@ -86,12 +86,6 @@ fn build_variant_from_captures(ident: &Ident, fields: Fields) -> TokenStream2 {
                         ),
                         state
                     );
-                    if val.is_some() {
-                        return (val, state);
-                    }
-                    state
-                } else {
-                    state
                 };
             };
         }
@@ -135,9 +129,9 @@ fn build_variant_from_captures(ident: &Ident, fields: Fields) -> TokenStream2 {
 
             quote! {
                 // TODO put an annotation here allowing unused muts.
-                let mut state = if let Some(mut captures) = matcher.capture_route_into_vec(&route_string).ok().map(|x| x.1) {
+                if let Some(mut captures) = matcher.capture_route_into_vec(&route_string).ok().map(|x| x.1) {
                     let mut drain = captures.drain(..);
-                    let (val, state) = (
+                    return (
                         Some(
                             #ident(
                                 #(#fields),*
@@ -145,12 +139,6 @@ fn build_variant_from_captures(ident: &Ident, fields: Fields) -> TokenStream2 {
                         ),
                         state
                     );
-                    if val.is_some() {
-                        return (val, state);
-                    }
-                    state
-                } else {
-                    state
                 };
             }
 

--- a/crates/yew_router_macro/src/switch/struct_impl.rs
+++ b/crates/yew_router_macro/src/switch/struct_impl.rs
@@ -50,7 +50,7 @@ fn build_variant_from_captures(ident: &Ident, fields: &Fields) -> TokenStream2 {
                         #field_name: {
                             let (v, s) = match captures.remove(#key) {
                                 Some(value) => {
-                                    <#field_ty as ::yew_router::RouteItem>::from_route_part(
+                                    <#field_ty as ::yew_router::Switch>::from_route_part(
                                         ::yew_router::route::Route {
                                             route: value,
                                             state,
@@ -59,7 +59,7 @@ fn build_variant_from_captures(ident: &Ident, fields: &Fields) -> TokenStream2 {
                                 }
                                 None => {
                                     (
-                                        <#field_ty as ::yew_router::RouteItem>::key_not_available(),
+                                        <#field_ty as ::yew_router::Switch>::key_not_available(),
                                         state,
                                     )
                                 }
@@ -100,7 +100,7 @@ fn build_variant_from_captures(ident: &Ident, fields: &Fields) -> TokenStream2 {
                             {
                                 let (v, s) = match drain.next() {
                                     Some((_key, value)) => {
-                                        <#field_ty as ::yew_router::RouteItem>::from_route_part(
+                                        <#field_ty as ::yew_router::Switch>::from_route_part(
                                             ::yew_router::route::Route {
                                                 route: value,
                                                 state,
@@ -109,7 +109,7 @@ fn build_variant_from_captures(ident: &Ident, fields: &Fields) -> TokenStream2 {
                                     },
                                     None => {
                                         (
-                                            <#field_ty as ::yew_router::RouteItem>::key_not_available(),
+                                            <#field_ty as ::yew_router::Switch>::key_not_available(),
                                             state,
                                         )
                                     }

--- a/crates/yew_router_route_parser/src/lib.rs
+++ b/crates/yew_router_route_parser/src/lib.rs
@@ -15,9 +15,7 @@ pub mod parser;
 mod token_optimizer;
 
 pub use parser::{Capture, CaptureVariant};
-use std::collections::{HashMap, HashSet};
-use std::error::Error;
-use std::fmt::{Display, Formatter};
+use std::collections::{HashMap};
 pub use token_optimizer::{
     next_delimiters, optimize_tokens, parse_str_and_optimize_tokens, MatcherToken,
 };

--- a/crates/yew_router_route_parser/src/lib.rs
+++ b/crates/yew_router_route_parser/src/lib.rs
@@ -25,4 +25,3 @@ pub use token_optimizer::{
 /// Captures contain keys corresponding to named match sections,
 /// and values containing the content captured by those sections.
 pub type Captures<'a> = HashMap<&'a str, String>;
-

--- a/examples/switch/src/main.rs
+++ b/examples/switch/src/main.rs
@@ -28,7 +28,7 @@ fn main() {
     dbg!(app_route);
 }
 use yew_router::route::Route;
-use yew_router::{Switch};
+use yew_router::Switch;
 
 #[derive(Debug, Switch)]
 pub enum AppRoute {
@@ -49,7 +49,6 @@ pub enum AppRoute {
     OtherSingle(OtherSingle),
 }
 
-
 #[derive(Switch, Debug)]
 pub enum InnerRoute {
     #[lit = "left"] // same as #[to = "/left"]
@@ -67,6 +66,3 @@ pub struct Single {
 #[derive(Switch, Debug)]
 #[to = "/othersingle/{number}"]
 pub struct OtherSingle(u32);
-
-
-

--- a/examples/switch/src/main.rs
+++ b/examples/switch/src/main.rs
@@ -27,17 +27,24 @@ fn main() {
     let app_route = AppRoute::switch(route);
     dbg!(app_route);
 
-
     let mut buf = String::new();
     AppRoute::Another("yeet".to_string()).build_route_section::<()>(&mut buf);
     println!("{}", buf);
 
     let mut buf = String::new();
-    AppRoute::Something{thing: "yeet".to_string(), other: "yote".to_string()}.build_route_section::<()>(&mut buf);
+    AppRoute::Something {
+        thing: "yeet".to_string(),
+        other: "yote".to_string(),
+    }
+    .build_route_section::<()>(&mut buf);
+    println!("{}", buf);
+
+    let mut buf = String::new();
+    OtherSingle(23).build_route_section::<()>(&mut buf);
     println!("{}", buf);
 }
 use yew_router::route::Route;
-use yew_router::{Switch};
+use yew_router::Switch;
 
 #[derive(Debug, Switch)]
 pub enum AppRoute {

--- a/examples/switch/src/main.rs
+++ b/examples/switch/src/main.rs
@@ -3,7 +3,7 @@ fn main() {
     let app_route = AppRoute::switch(route);
     dbg!(app_route);
 
-    let route = Route::<()>::from("/some/other");
+    let route = Route::<()>::from("/some/thing/other");
     let app_route = AppRoute::switch(route);
     dbg!(app_route);
 
@@ -15,22 +15,22 @@ fn main() {
     let app_route = AppRoute::switch(route);
     dbg!(app_route);
 
-    let route = Route::<()>::from("/yeet");
+    let route = Route::<()>::from("/yeet"); // should not match
     let app_route = AppRoute::switch(route);
     dbg!(app_route);
 
-    let route = Route::<()>::from("/single/32");
-    let app_route = AppRoute::switch(route);
-    dbg!(app_route);
-
-    let route = Route::<()>::from("/othersingle/472");
-    let app_route = AppRoute::switch(route);
-    dbg!(app_route);
+//    let route = Route::<()>::from("/single/32");
+//    let app_route = AppRoute::switch(route);
+//    dbg!(app_route);
+//
+//    let route = Route::<()>::from("/othersingle/472");
+//    let app_route = AppRoute::switch(route);
+//    dbg!(app_route);
 }
 use yew_router::route::Route;
-use yew_router::Switch;
+use yew_router::{Switch, RouteItem};
 
-#[derive(Switch, Debug)]
+#[derive(Debug, Switch)]
 pub enum AppRoute {
     #[to = "/some/route"]
     SomeRoute,
@@ -38,14 +38,17 @@ pub enum AppRoute {
     Something { thing: String, other: String },
     #[to = "/another/{thing}"]
     Another(String),
+    #[to = "/doot/{one}/{two}"]
+    Yeet(String, String),
     #[lit = "inner"]
     #[rest]
     Nested(InnerRoute),
-    #[rest]
-    Single(Single),
-    #[rest]
-    OtherSingle(OtherSingle),
+//    #[rest]
+//    Single(Single),
+//    #[rest]
+//    OtherSingle(OtherSingle),
 }
+
 
 #[derive(Switch, Debug)]
 pub enum InnerRoute {
@@ -55,12 +58,12 @@ pub enum InnerRoute {
     Right,
 }
 
-#[derive(Switch, Debug)]
-#[to = "/single/{number}"]
-pub struct Single {
-    number: u32,
-}
-
-#[derive(Switch, Debug)]
-#[to = "/othersingle/{number}"]
-pub struct OtherSingle(u32);
+//#[derive(Switch, Debug)]
+//#[to = "/single/{number}"]
+//pub struct Single {
+//    number: u32,
+//}
+//
+//#[derive(Switch, Debug)]
+//#[to = "/othersingle/{number}"]
+//pub struct OtherSingle(u32);

--- a/examples/switch/src/main.rs
+++ b/examples/switch/src/main.rs
@@ -19,16 +19,16 @@ fn main() {
     let app_route = AppRoute::switch(route);
     dbg!(app_route);
 
-//    let route = Route::<()>::from("/single/32");
-//    let app_route = AppRoute::switch(route);
-//    dbg!(app_route);
-//
-//    let route = Route::<()>::from("/othersingle/472");
-//    let app_route = AppRoute::switch(route);
-//    dbg!(app_route);
+    let route = Route::<()>::from("/single/32");
+    let app_route = AppRoute::switch(route);
+    dbg!(app_route);
+
+    let route = Route::<()>::from("/othersingle/472");
+    let app_route = AppRoute::switch(route);
+    dbg!(app_route);
 }
 use yew_router::route::Route;
-use yew_router::{Switch, RouteItem};
+use yew_router::{Switch};
 
 #[derive(Debug, Switch)]
 pub enum AppRoute {
@@ -43,10 +43,10 @@ pub enum AppRoute {
     #[lit = "inner"]
     #[rest]
     Nested(InnerRoute),
-//    #[rest]
-//    Single(Single),
-//    #[rest]
-//    OtherSingle(OtherSingle),
+    #[rest]
+    Single(Single),
+    #[rest]
+    OtherSingle(OtherSingle),
 }
 
 
@@ -58,12 +58,15 @@ pub enum InnerRoute {
     Right,
 }
 
-//#[derive(Switch, Debug)]
-//#[to = "/single/{number}"]
-//pub struct Single {
-//    number: u32,
-//}
-//
-//#[derive(Switch, Debug)]
-//#[to = "/othersingle/{number}"]
-//pub struct OtherSingle(u32);
+#[derive(Switch, Debug)]
+#[to = "/single/{number}"]
+pub struct Single {
+    number: u32,
+}
+
+#[derive(Switch, Debug)]
+#[to = "/othersingle/{number}"]
+pub struct OtherSingle(u32);
+
+
+

--- a/examples/switch/src/main.rs
+++ b/examples/switch/src/main.rs
@@ -31,6 +31,10 @@ fn main() {
     let mut buf = String::new();
     AppRoute::Another("yeet".to_string()).build_route_section::<()>(&mut buf);
     println!("{}", buf);
+
+    let mut buf = String::new();
+    AppRoute::Something{thing: "yeet".to_string(), other: "yote".to_string()}.build_route_section::<()>(&mut buf);
+    println!("{}", buf);
 }
 use yew_router::route::Route;
 use yew_router::{Switch};
@@ -45,9 +49,9 @@ pub enum AppRoute {
     Another(String),
     #[to = "/doot/{one}/{two}"]
     Yeet(String, String),
-    #[lit = "inner"]
-    #[rest]
-    Nested(InnerRoute),
+//    #[lit = "inner"]
+//    #[rest]
+//    Nested(InnerRoute),
 //    #[rest]
 //    Single(Single),
 //    #[rest]

--- a/examples/switch/src/main.rs
+++ b/examples/switch/src/main.rs
@@ -26,23 +26,28 @@ fn main() {
     let route = Route::<()>::from("/othersingle/472");
     let app_route = AppRoute::switch(route);
     dbg!(app_route);
+
+
+    let mut buf = String::new();
+    AppRoute::Another("yeet".to_string()).build_route_section::<()>(&mut buf);
+    println!("{}", buf);
 }
 use yew_router::route::Route;
-use yew_router::Switch;
+use yew_router::{Switch};
 
 #[derive(Debug, Switch)]
 pub enum AppRoute {
-//    #[to = "/some/route"]
-//    SomeRoute,
-//    #[to = "/some/{thing}/{other}"]
-//    Something { thing: String, other: String },
+    #[to = "/some/route"]
+    SomeRoute,
+    #[to = "/some/{thing}/{other}"]
+    Something { thing: String, other: String },
     #[to = "/another/{thing}"]
     Another(String),
-//    #[to = "/doot/{one}/{two}"]
-//    Yeet(String, String),
-//    #[lit = "inner"]
-//    #[rest]
-//    Nested(InnerRoute),
+    #[to = "/doot/{one}/{two}"]
+    Yeet(String, String),
+    #[lit = "inner"]
+    #[rest]
+    Nested(InnerRoute),
 //    #[rest]
 //    Single(Single),
 //    #[rest]

--- a/examples/switch/src/main.rs
+++ b/examples/switch/src/main.rs
@@ -49,13 +49,13 @@ pub enum AppRoute {
     Another(String),
     #[to = "/doot/{one}/{two}"]
     Yeet(String, String),
-//    #[lit = "inner"]
-//    #[rest]
-//    Nested(InnerRoute),
-//    #[rest]
-//    Single(Single),
-//    #[rest]
-//    OtherSingle(OtherSingle),
+    #[lit = "inner"]
+    #[rest]
+    Nested(InnerRoute),
+    #[rest]
+    Single(Single),
+    #[rest]
+    OtherSingle(OtherSingle),
 }
 
 #[derive(Switch, Debug)]

--- a/examples/switch/src/main.rs
+++ b/examples/switch/src/main.rs
@@ -32,21 +32,21 @@ use yew_router::Switch;
 
 #[derive(Debug, Switch)]
 pub enum AppRoute {
-    #[to = "/some/route"]
-    SomeRoute,
-    #[to = "/some/{thing}/{other}"]
-    Something { thing: String, other: String },
+//    #[to = "/some/route"]
+//    SomeRoute,
+//    #[to = "/some/{thing}/{other}"]
+//    Something { thing: String, other: String },
     #[to = "/another/{thing}"]
     Another(String),
-    #[to = "/doot/{one}/{two}"]
-    Yeet(String, String),
-    #[lit = "inner"]
-    #[rest]
-    Nested(InnerRoute),
-    #[rest]
-    Single(Single),
-    #[rest]
-    OtherSingle(OtherSingle),
+//    #[to = "/doot/{one}/{two}"]
+//    Yeet(String, String),
+//    #[lit = "inner"]
+//    #[rest]
+//    Nested(InnerRoute),
+//    #[rest]
+//    Single(Single),
+//    #[rest]
+//    OtherSingle(OtherSingle),
 }
 
 #[derive(Switch, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,8 +104,7 @@ pub use crate::route::RouteState;
 pub use crate::router::RouterState;
 
 mod switch;
-pub use switch::Switch;
-//pub use switch::RouteItem;
+pub use switch::{Switch, build_route_from_switch};
 pub use yew_router_macro::Switch;
 
 /// The route macro produces a Matcher which can be used to determine if a route string should cause

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,8 +103,8 @@ pub use crate::route::RouteState;
 #[cfg(feature = "router")]
 pub use crate::router::RouterState;
 
-mod switch;
-pub use switch::{Switch, build_route_from_switch};
+pub mod switch;
+pub use switch::{Switch};
 pub use yew_router_macro::Switch;
 
 /// The route macro produces a Matcher which can be used to determine if a route string should cause

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ pub use crate::router::RouterState;
 
 mod switch;
 pub use switch::Switch;
+pub use switch::RouteItem;
 pub use yew_router_macro::Switch;
 
 /// The route macro produces a Matcher which can be used to determine if a route string should cause

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ pub use crate::router::RouterState;
 
 mod switch;
 pub use switch::Switch;
-pub use switch::RouteItem;
+//pub use switch::RouteItem;
 pub use yew_router_macro::Switch;
 
 /// The route macro produces a Matcher which can be used to determine if a route string should cause

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub mod unit_state {
 
 /// Prelude crate that can be imported when working with the yew_router
 pub mod prelude {
-    pub use super::matcher::{Captures};
+    pub use super::matcher::Captures;
     #[cfg(feature = "unit_alias")]
     pub use super::unit_state::*;
     pub use crate::switch::Switch;
@@ -95,7 +95,7 @@ pub use alias::*;
 
 pub mod matcher;
 
-pub use matcher::{Captures};
+pub use matcher::Captures;
 
 #[cfg(feature = "agent")]
 pub use crate::agent::AgentState;

--- a/src/matcher/mod.rs
+++ b/src/matcher/mod.rs
@@ -4,6 +4,5 @@ pub use yew_router_route_parser::{
     parser::YewRouterParseError, Capture, CaptureVariant, Captures, MatcherToken,
 };
 
-
 mod route_matcher;
 pub use self::route_matcher::{MatcherSettings, RouteMatcher};

--- a/src/matcher/route_matcher/match_paths.rs
+++ b/src/matcher/route_matcher/match_paths.rs
@@ -347,7 +347,8 @@ where
 //    is_not(INVALID_CHARACTERS)(i)
 //}
 
-#[cfg(test)]
+//#[cfg(test)]
+#[cfg(feature = "disabled")]
 mod integration_test {
     use super::*;
 

--- a/src/matcher/route_matcher/mod.rs
+++ b/src/matcher/route_matcher/mod.rs
@@ -1,8 +1,6 @@
 //! Module for matching route strings based on tokens generated from the yew_router_route_parser crate.
 
-pub use yew_router_route_parser::{
-    Capture, CaptureVariant, MatcherToken,
-};
+pub use yew_router_route_parser::{Capture, CaptureVariant, MatcherToken};
 
 mod match_paths;
 mod util;

--- a/src/route.rs
+++ b/src/route.rs
@@ -55,7 +55,7 @@ impl<T> Route<T> {
     }
 
     /// Replace the route with a new string.
-    pub (crate) fn replace_route(&mut self, new_route: &str) {
+    pub(crate) fn replace_route(&mut self, new_route: &str) {
         self.route.replace_range(.., new_route)
     }
 }

--- a/src/route.rs
+++ b/src/route.rs
@@ -53,6 +53,11 @@ impl<T> Route<T> {
     pub fn to_string(&self) -> String {
         self.route.to_string()
     }
+
+    /// Replace the route with a new string.
+    pub (crate) fn replace_route(&mut self, new_route: &str) {
+        self.route.replace_range(.., new_route)
+    }
 }
 
 impl<T> From<String> for Route<T> {

--- a/src/route.rs
+++ b/src/route.rs
@@ -53,11 +53,6 @@ impl<T> Route<T> {
     pub fn to_string(&self) -> String {
         self.route.to_string()
     }
-
-    /// Replace the route with a new string.
-    pub(crate) fn replace_route(&mut self, new_route: &str) {
-        self.route.replace_range(.., new_route)
-    }
 }
 
 impl<T> From<String> for Route<T> {

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -49,7 +49,7 @@ use yew::{
 ///         html! {
 ///             <Router<(), S, Msg>
 ///                callback = From::from
-///                render = Router::render(|switch: Option<&S>| {
+///                render = Router::render(|switch: Option<S>| {
 ///                    match switch {
 ///                        Some(S::Variant) => html!{"variant route was matched"},
 ///                        _ => unimplemented!()
@@ -87,7 +87,7 @@ where
     ///# pub enum Msg {}
     ///
     ///# fn dont_execute() {
-    /// let render = Router::render(|switch: Option<&S>| -> Html<Router<(), S, Msg>> {
+    /// let render = Router::render(|switch: Option<S>| -> Html<Router<(), S, Msg>> {
     ///    match switch {
     ///        Some(S::Variant) => html!{"Variant"},
     ///        None => html!{"404"}

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -202,7 +202,7 @@ impl<T: for<'de> RouterState<'de>, SW: Switch + 'static, M: 'static> Renderable<
     for Router<T, SW, M>
 {
     fn view(&self) -> VNode<Self> {
-        let switch = SW::switch(self.route.clone());
+        let switch: Option<SW>= SW::switch(self.route.clone());
         (&self.props.render.0)(switch)
     }
 }

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -202,7 +202,7 @@ impl<T: for<'de> RouterState<'de>, SW: Switch + 'static, M: 'static> Renderable<
     for Router<T, SW, M>
 {
     fn view(&self) -> VNode<Self> {
-        let switch: Option<SW>= SW::switch(self.route.clone());
+        let switch: Option<SW> = SW::switch(self.route.clone());
         (&self.props.render.0)(switch)
     }
 }

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -8,8 +8,6 @@ use std::fmt::Write;
 /// # Note
 /// Don't try to implement this yourself, rely on the derive macro.
 ///
-/// If you want to dictate how an item is serialized/deserialized to a route string, implement `RouteItem` instead.
-///
 /// # Example
 /// ```
 /// use yew_router::Switch;
@@ -64,8 +62,12 @@ pub fn build_route_from_switch<T: Switch, U>(switch: T) -> Route<U> {
 }
 
 
-/// Wrapper that allows any implementor of RouteItem to be treated as a switch.
-/// It stipulates that the first character must be a slash.
+/// Wrapper that requires that an implementor of Switch must start with a `/`.
+///
+/// This is needed for any non-derived type provided by yew-router to be used by itself.
+///
+/// This is because route strings will almost always start with `/`, so in order to get a std type
+/// with the `rest` attribute, without a specified leading `/`, this wrapper is needed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct LeadingSlash<T>(pub T);
 impl <U: Switch> Switch for LeadingSlash<U> {

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -54,12 +54,6 @@ pub trait Switch: Sized {
     }
 }
 
-// Ok, the pattern is:
-// Provide route
-// For each match, pull the expected item out of the hashmap,
-// create a Route comprised of that item, and the state.
-// Rescue the state afterwords to move it into the next item.
-
 /// Builds a route from a switch.
 pub fn build_route_from_switch<T: Switch, U>(switch: T) -> Route<U> {
     let mut buf = String::with_capacity(50); // TODO, play with this to maximize perf/size.

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -62,22 +62,14 @@ pub trait Switch: Sized {
 // create a Route comprised of that item, and the state.
 // Rescue the state afterwords to move it into the next item.
 
-
-
 /// Builds a route from a switch.
 pub fn build_route_from_switch<T: Switch, U>(switch: T) -> Route<U> {
     let mut buf = String::with_capacity(50); // TODO, play with this to maximize perf/size.
 
     let state: Option<U> = None;
-    let state = state.or( switch.build_route_section(&mut buf));
-    Route {
-        route: buf,
-        state
-    }
+    let state = state.or(switch.build_route_section(&mut buf));
+    Route { route: buf, state }
 }
-
-
-
 
 //impl <U: RouteItem> RouteItem for Option<U> {
 //    fn from_route_part<T: RouteState>(part: &mut Route<T>) -> Option<Self> {
@@ -110,8 +102,6 @@ pub fn build_route_from_switch<T: Switch, U>(switch: T) -> Route<U> {
 //        None
 //    }
 //}
-
-
 
 macro_rules! impl_switch_for_from_to_str {
     ($($SelfT: ty),*) => {
@@ -162,7 +152,6 @@ impl_switch_for_from_to_str! {
     std::num::NonZeroI8
 }
 
-
 #[test]
 fn isize_build_route() {
     let mut route = "/".to_string();
@@ -170,7 +159,6 @@ fn isize_build_route() {
     state.or((-432isize).build_route_section(&mut route));
     assert_eq!(route, "/-432".to_string());
 }
-
 
 //impl<U: Switch> Switch for Option<U> {
 //    fn switch<T: RouteState>(route: Route<T>) -> Option<Self> {
@@ -203,7 +191,6 @@ fn isize_build_route() {
 //        )*
 //    };
 //}
-
 
 // TODO add implementations for Dates - with various formats, UUIDs
 //impl_switch_for_from_str! {

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -72,6 +72,7 @@ pub fn build_route_from_switch<T: Switch, U>(switch: T) -> Route<U> {
 
 /// Wrapper that allows any implementor of RouteItem to be treated as a switch.
 /// It stipulates that the first character must be a slash.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct LeadingSlash<T>(pub T);
 impl <U: Switch> Switch for LeadingSlash<U> {
     fn from_route_part<T: RouteState>(part: Route<T>) -> (Option<Self>, Option<T>) {

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -113,7 +113,7 @@ macro_rules! impl_switch_for_from_to_str {
             }
 
             fn build_route_section<T>(self, f: &mut String) -> Option<T> {
-                write!(f, "{}", self).ok()?; // TODO no idea if this works or not.
+                write!(f, "{}", self).expect("Writing to string should never fail.");
                 None
             }
         }

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -24,8 +24,6 @@ use std::fmt::Write;
 ///     CaptureNumber{num: usize},
 ///     #[to = "/capture/unnamed/{doot}"]
 ///     CaptureUnnamed(String),
-///     #[to = "{*}/skip/"]
-///     Skip
 /// }
 ///
 /// assert_eq!(TestEnum::switch(Route::<()>::from("/test/route")), Some(TestEnum::TestRoute));
@@ -155,8 +153,8 @@ impl_switch_for_from_to_str! {
 #[test]
 fn isize_build_route() {
     let mut route = "/".to_string();
-    let mut state: Option<String> = None;
-    state.or((-432isize).build_route_section(&mut route));
+    let mut _state: Option<String> = None;
+    _state = _state.or((-432isize).build_route_section(&mut route));
     assert_eq!(route, "/-432".to_string());
 }
 

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -3,6 +3,7 @@ use crate::route::Route;
 use crate::RouteState;
 use std::str::FromStr;
 use std::path::PathBuf;
+use std::fmt;
 
 /// Routing trait for enums
 ///
@@ -40,6 +41,102 @@ pub trait Switch: Sized {
         None
     }
 }
+
+
+
+pub struct RoutePart<'a, T> {
+    route: &'a str,
+    state: Option<T>
+}
+
+pub trait RouteItem: Sized {
+    fn from_route_part<T>(part: &mut RoutePart<T>) -> Option<Self>;
+
+    fn build_route_section<T>(self, route: &mut String) -> Option<T>;
+
+    fn key_not_available() -> Option<Self> {
+        None
+    }
+}
+
+impl <U: RouteItem> RouteItem for Option<U> {
+    fn from_route_part<T>(part: &mut RoutePart<'_, T>) -> Option<Self> {
+        Some(Some(RouteItem::from_route_part(part)?)) // TODO not 100% sure about the semantics of this.
+    }
+
+    fn build_route_section<T>(self, f: &mut String) -> Option<T> {
+        if let Some(item) = self {
+            item.build_route_section(f)
+        } else {
+            None
+        }
+    }
+
+    fn key_not_available() -> Option<Self> {
+        Some(None)
+    }
+}
+
+use fmt::Display;
+use std::fmt::Write;
+
+macro_rules! impl_route_item_for_from_to_str {
+    ($($SelfT: ty),*) => {
+        $(
+        impl RouteItem for $SelfT {
+            fn from_route_part<T>(part: &mut RoutePart<'_, T>) -> Option<Self> {
+                ::std::str::FromStr::from_str(&part.route).ok()
+            }
+
+            fn build_route_section<T>(self, f: &mut String) -> Option<T> {
+                write!(f, "{}", self).ok()?; // TODO no idea if this works or not.
+                None
+            }
+        }
+        )*
+    };
+}
+
+impl_route_item_for_from_to_str! {
+    String,
+    bool,
+    f64,
+    f32,
+    usize,
+    u128,
+    u64,
+    u32,
+    u16,
+    u8,
+    isize,
+    i128,
+    i64,
+    i32,
+    i16,
+    i8,
+    std::num::NonZeroU128,
+    std::num::NonZeroU64,
+    std::num::NonZeroU32,
+    std::num::NonZeroU16,
+    std::num::NonZeroU8,
+    std::num::NonZeroI128,
+    std::num::NonZeroI64,
+    std::num::NonZeroI32,
+    std::num::NonZeroI16,
+    std::num::NonZeroI8
+}
+
+
+#[test]
+fn isize_build_route() {
+    let mut route = "/".to_string();
+    let mut state: Option<String> = None;
+    state.or((-432isize).build_route_section(&mut route));
+    assert_eq!(route, "/-432".to_string());
+}
+
+
+
 
 impl<U: Switch> Switch for Option<U> {
     fn switch<T: RouteState>(route: Route<T>) -> Option<Self> {

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -72,7 +72,7 @@ pub fn build_route_from_switch<T: Switch, U>(switch: T) -> Route<U> {
 
 /// Wrapper that allows any implementor of RouteItem to be treated as a switch.
 /// It stipulates that the first character must be a slash.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct LeadingSlash<T>(pub T);
 impl <U: Switch> Switch for LeadingSlash<U> {
     fn from_route_part<T: RouteState>(part: Route<T>) -> (Option<Self>, Option<T>) {

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -2,6 +2,7 @@
 use crate::route::Route;
 use crate::RouteState;
 use std::str::FromStr;
+use std::path::PathBuf;
 
 /// Routing trait for enums
 ///
@@ -72,20 +73,12 @@ macro_rules! impl_switch_for_from_str {
     };
 }
 
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
-use std::path::PathBuf;
 
 // TODO add implementations for Dates - with various formats, UUIDs
 impl_switch_for_from_str! {
     String,
     PathBuf,
     bool,
-    IpAddr,
-    Ipv4Addr,
-    Ipv6Addr,
-    SocketAddr,
-    SocketAddrV4,
-    SocketAddrV6,
     f64,
     f32,
     usize,


### PR DESCRIPTION
This PR reworks the Switch trait, ~adding a secondary trait that is used to define how datatypes like primatives and std types are taken from a route~.

As a consequence of this rework, `clone`s are avoided.

It also aims to add support for adding serialization of Switches to Routes: https://github.com/yewstack/yew_router/issues/107