### PR TITLE
Simplify Matcher Token

### DIFF
--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -119,7 +119,7 @@ fn write_for_token(token: &ShadowMatcherToken, naming_scheme: FieldType) -> Toke
         }
         ShadowMatcherToken::Capture(capture) => {
             match naming_scheme {
-                FieldType::Named | FieldType::Unit => match &capture.capture_variant {
+                FieldType::Named | FieldType::Unit => match &capture {
                     ShadowCaptureVariant::Unnamed => {
                         panic!("Unnamed sections not supported for writing")
                     }
@@ -139,7 +139,7 @@ fn write_for_token(token: &ShadowMatcherToken, naming_scheme: FieldType) -> Toke
                     }
                 },
                 FieldType::Unnamed { index } => {
-                    match &capture.capture_variant {
+                    match &capture {
                         ShadowCaptureVariant::Unnamed => {
                             panic!("Unnamed sections not supported for writing")
                         }

--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -120,15 +120,6 @@ fn write_for_token(token: &ShadowMatcherToken, naming_scheme: FieldType) -> Toke
         ShadowMatcherToken::Capture(capture) => {
             match naming_scheme {
                 FieldType::Named | FieldType::Unit => match &capture {
-                    ShadowCaptureVariant::Unnamed => {
-                        panic!("Unnamed sections not supported for writing")
-                    }
-                    ShadowCaptureVariant::ManyUnnamed => {
-                        panic!("ManyUnnamed sections not supported for writing")
-                    }
-                    ShadowCaptureVariant::NumberedUnnamed { .. } => {
-                        panic!("NumberedUnnamed sections not supported for writing")
-                    }
                     ShadowCaptureVariant::Named(name)
                     | ShadowCaptureVariant::ManyNamed(name)
                     | ShadowCaptureVariant::NumberedNamed { name, .. } => {
@@ -140,15 +131,6 @@ fn write_for_token(token: &ShadowMatcherToken, naming_scheme: FieldType) -> Toke
                 },
                 FieldType::Unnamed { index } => {
                     match &capture {
-                        ShadowCaptureVariant::Unnamed => {
-                            panic!("Unnamed sections not supported for writing")
-                        }
-                        ShadowCaptureVariant::ManyUnnamed => {
-                            panic!("ManyUnnamed sections not supported for writing")
-                        }
-                        ShadowCaptureVariant::NumberedUnnamed { .. } => {
-                            panic!("NumberedUnnamed sections not supported for writing")
-                        }
                         ShadowCaptureVariant::Named(_)
                         | ShadowCaptureVariant::ManyNamed(_)
                         | ShadowCaptureVariant::NumberedNamed { .. } => {

--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -162,7 +162,6 @@ fn write_for_token(token: &ShadowMatcherToken, naming_scheme: FieldType) -> Toke
                 }
             }
         }
-        ShadowMatcherToken::Optional(_) => panic!("Writing optional sections is not supported."),
     }
 }
 

--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -91,7 +91,6 @@ impl<T> Flatten<T> for Option<Option<T>> {
 fn build_matcher_from_tokens(tokens: &[ShadowMatcherToken]) -> TokenStream2 {
     quote! {
         let settings = ::yew_router::matcher::MatcherSettings {
-            strict: true, // Don't add optional sections
             complete: false, // Allow incomplete matches. // TODO investigate if this is necessary here.
             case_insensitive: true,
         };

--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -218,7 +218,6 @@ pub fn build_serializer_for_enum(
     }
 }
 
-
 pub fn build_serializer_for_struct(switch_item: &SwitchItem, item: &Ident) -> TokenStream2 {
     let SwitchItem {
         matcher,

--- a/crates/yew_router_macro/src/switch/attribute.rs
+++ b/crates/yew_router_macro/src/switch/attribute.rs
@@ -1,4 +1,4 @@
-use crate::switch::shadow::{ShadowCapture, ShadowCaptureVariant, ShadowMatcherToken};
+use crate::switch::shadow::{ShadowCaptureVariant, ShadowMatcherToken};
 use syn::{Attribute, Lit, Meta, MetaNameValue};
 
 pub enum AttrToken {
@@ -92,64 +92,54 @@ impl AttrToken {
             AttrToken::Lit(lit) => vec![ShadowMatcherToken::Exact(format!("/{}", lit))],
             AttrToken::Capture(Some(capture_name)) => vec![
                 ShadowMatcherToken::Exact("/".to_string()),
-                ShadowMatcherToken::Capture(ShadowCapture {
-                    capture_variant: ShadowCaptureVariant::Named(capture_name),
-                    allowed_captures: None,
-                }),
+                ShadowMatcherToken::Capture(
+                     ShadowCaptureVariant::Named(capture_name),
+                ),
             ],
             AttrToken::Capture(None) => vec![
                 ShadowMatcherToken::Exact("/".to_string()),
-                ShadowMatcherToken::Capture(ShadowCapture {
-                    capture_variant: ShadowCaptureVariant::Named(id.to_string()),
-                    allowed_captures: None,
-                }),
+                ShadowMatcherToken::Capture(
+                    ShadowCaptureVariant::Named(id.to_string()),
+                ),
             ],
             AttrToken::End => unimplemented!(
                 "No matcher token currently exists for expressing the termination of a route"
             ),
             AttrToken::Rest(Some(capture_name)) => {
-                vec![ShadowMatcherToken::Capture(ShadowCapture {
-                    capture_variant: ShadowCaptureVariant::ManyNamed(capture_name),
-                    allowed_captures: None,
-                })]
+                vec![ShadowMatcherToken::Capture(
+                    ShadowCaptureVariant::ManyNamed(capture_name),
+                )]
             }
-            AttrToken::Rest(None) => vec![ShadowMatcherToken::Capture(ShadowCapture {
-                capture_variant: ShadowCaptureVariant::ManyNamed(id.to_string()),
-                allowed_captures: None,
-            })],
+            AttrToken::Rest(None) => vec![ShadowMatcherToken::Capture(
+                ShadowCaptureVariant::ManyNamed(id.to_string()),
+            )],
             AttrToken::Query(capture_name) => {
                 if *encountered_query {
                     vec![
                         ShadowMatcherToken::Exact(format!("&{}=", capture_name)),
-                        ShadowMatcherToken::Capture(ShadowCapture {
-                            capture_variant: ShadowCaptureVariant::Named(capture_name),
-                            allowed_captures: None,
-                        }),
+                        ShadowMatcherToken::Capture(
+                             ShadowCaptureVariant::Named(capture_name),
+                        ),
                     ]
                 } else {
                     *encountered_query = true;
                     vec![
                         ShadowMatcherToken::Exact(format!("?{}=", capture_name)),
-                        ShadowMatcherToken::Capture(ShadowCapture {
-                            capture_variant: ShadowCaptureVariant::Named(capture_name),
-                            allowed_captures: None,
-                        }),
+                        ShadowMatcherToken::Capture(ShadowCaptureVariant::Named(capture_name)),
                     ]
                 }
             }
             AttrToken::Frag(Some(capture_name)) => vec![
                 ShadowMatcherToken::Exact("#".to_string()),
-                ShadowMatcherToken::Capture(ShadowCapture {
-                    capture_variant: ShadowCaptureVariant::Named(capture_name),
-                    allowed_captures: None,
-                }),
+                ShadowMatcherToken::Capture(
+                    ShadowCaptureVariant::Named(capture_name),
+                ),
             ],
             AttrToken::Frag(None) => vec![
                 ShadowMatcherToken::Exact("#".to_string()),
-                ShadowMatcherToken::Capture(ShadowCapture {
-                    capture_variant: ShadowCaptureVariant::Named(id.to_string()),
-                    allowed_captures: None,
-                }),
+                ShadowMatcherToken::Capture(
+                    ShadowCaptureVariant::Named(id.to_string()),
+                ),
             ],
         }
     }

--- a/crates/yew_router_macro/src/switch/attribute.rs
+++ b/crates/yew_router_macro/src/switch/attribute.rs
@@ -92,24 +92,18 @@ impl AttrToken {
             AttrToken::Lit(lit) => vec![ShadowMatcherToken::Exact(format!("/{}", lit))],
             AttrToken::Capture(Some(capture_name)) => vec![
                 ShadowMatcherToken::Exact("/".to_string()),
-                ShadowMatcherToken::Capture(
-                     ShadowCaptureVariant::Named(capture_name),
-                ),
+                ShadowMatcherToken::Capture(ShadowCaptureVariant::Named(capture_name)),
             ],
             AttrToken::Capture(None) => vec![
                 ShadowMatcherToken::Exact("/".to_string()),
-                ShadowMatcherToken::Capture(
-                    ShadowCaptureVariant::Named(id.to_string()),
-                ),
+                ShadowMatcherToken::Capture(ShadowCaptureVariant::Named(id.to_string())),
             ],
             AttrToken::End => unimplemented!(
                 "No matcher token currently exists for expressing the termination of a route"
             ),
-            AttrToken::Rest(Some(capture_name)) => {
-                vec![ShadowMatcherToken::Capture(
-                    ShadowCaptureVariant::ManyNamed(capture_name),
-                )]
-            }
+            AttrToken::Rest(Some(capture_name)) => vec![ShadowMatcherToken::Capture(
+                ShadowCaptureVariant::ManyNamed(capture_name),
+            )],
             AttrToken::Rest(None) => vec![ShadowMatcherToken::Capture(
                 ShadowCaptureVariant::ManyNamed(id.to_string()),
             )],
@@ -117,9 +111,7 @@ impl AttrToken {
                 if *encountered_query {
                     vec![
                         ShadowMatcherToken::Exact(format!("&{}=", capture_name)),
-                        ShadowMatcherToken::Capture(
-                             ShadowCaptureVariant::Named(capture_name),
-                        ),
+                        ShadowMatcherToken::Capture(ShadowCaptureVariant::Named(capture_name)),
                     ]
                 } else {
                     *encountered_query = true;
@@ -131,15 +123,11 @@ impl AttrToken {
             }
             AttrToken::Frag(Some(capture_name)) => vec![
                 ShadowMatcherToken::Exact("#".to_string()),
-                ShadowMatcherToken::Capture(
-                    ShadowCaptureVariant::Named(capture_name),
-                ),
+                ShadowMatcherToken::Capture(ShadowCaptureVariant::Named(capture_name)),
             ],
             AttrToken::Frag(None) => vec![
                 ShadowMatcherToken::Exact("#".to_string()),
-                ShadowMatcherToken::Capture(
-                    ShadowCaptureVariant::Named(id.to_string()),
-                ),
+                ShadowMatcherToken::Capture(ShadowCaptureVariant::Named(id.to_string())),
             ],
         }
     }

--- a/crates/yew_router_macro/src/switch/attribute.rs
+++ b/crates/yew_router_macro/src/switch/attribute.rs
@@ -83,7 +83,7 @@ impl AttrToken {
         match self {
             AttrToken::To(matcher_string) => {
                 yew_router_route_parser::parser::parse(&matcher_string)
-                    .map(|tokens| yew_router_route_parser::optimize_tokens(tokens, false))
+                    .map(|tokens| yew_router_route_parser::optimize_tokens(tokens))
                     .expect("Invalid Matcher") // This is the point where users should see an error message if their matcher string has some syntax error.
                     .into_iter()
                     .map(crate::switch::shadow::ShadowMatcherToken::from)

--- a/crates/yew_router_macro/src/switch/enum_impl.rs
+++ b/crates/yew_router_macro/src/switch/enum_impl.rs
@@ -6,25 +6,21 @@ use syn::export::TokenStream2;
 use syn::{Field, Fields, Ident, Type};
 
 pub fn generate_enum_impl(enum_ident: Ident, switch_variants: Vec<SwitchItem>) -> TokenStream {
+    let variant_matchers = switch_variants.iter().map(|sv| {
+        let SwitchItem {
+            matcher,
+            ident,
+            fields,
+        } = sv;
+        let build_from_captures = build_variant_from_captures(&enum_ident, ident, fields);
+        let matcher = super::build_matcher_from_tokens(&matcher);
 
-
-    let variant_matchers = switch_variants
-        .iter()
-        .map(|sv| {
-            let SwitchItem {
-                matcher,
-                ident,
-                fields,
-            } = sv;
-            let build_from_captures = build_variant_from_captures(&enum_ident, ident, fields);
-            let matcher = super::build_matcher_from_tokens(&matcher);
-
-            quote! {
-                #matcher
-                #build_from_captures
-            }
-        });
-//        .collect::<Vec<_>>();
+        quote! {
+            #matcher
+            #build_from_captures
+        }
+    });
+    //        .collect::<Vec<_>>();
 
     let match_item = Ident::new("self", Span::call_site());
     let serializer = build_serializer_for_enum(&switch_variants, &enum_ident, &match_item);
@@ -59,7 +55,9 @@ fn build_variant_from_captures(
 ) -> TokenStream2 {
     match fields {
         Fields::Named(named_fields) => {
-            let fields: Vec<TokenStream2> = named_fields.named.iter()
+            let fields: Vec<TokenStream2> = named_fields
+                .named
+                .iter()
                 .filter_map(|field: &Field| {
                     let field_ty: &Type = &field.ty;
                     field.ident.as_ref().map(|i: &Ident| {
@@ -67,74 +65,18 @@ fn build_variant_from_captures(
                         (i, key, field_ty)
                     })
                 })
-                .map(|(field_name, key, field_ty): (&Ident, String, &Type)|{
-                    quote!{
-                            #field_name: {
-                                let (v, s) = match captures.remove(#key) {
-                                    Some(value) => {
-                                        <#field_ty as ::yew_router::Switch>::from_route_part(
-                                            ::yew_router::route::Route {
-                                                route: value,
-                                                state,
-                                            }
-                                        )
-                                    }
-                                    None => {
-                                        (
-                                            <#field_ty as ::yew_router::Switch>::key_not_available(),
-                                            state,
-                                        )
-                                    }
-                                };
-                                match v {
-                                    Some(val) => {
-                                        state = s; // Set state for the next var.
-                                        val
-                                    },
-                                    None => return (None, s) // Failed
-                                }
-                            }
-                        }
-                })
-                .collect();
-
-            quote! {
-                    let mut state = if let Some(mut captures) = matcher.capture_route_into_map(&route_string).ok().map(|x| x.1) {
-                        let create_item = || {
-                             (
-                                Some(
-                                    #enum_ident::#variant_ident {
-                                        #(#fields),*
-                                    }
-                                ),
-                                state
-                            )
-                        };
-                        let (val, state) = create_item();
-
-                        if val.is_some() {
-                            return (val, state);
-                        }
-                        state
-                    } else {
-                        state
-                    };
-                }
-        }
-        Fields::Unnamed(unnamed_fields) => {
-            let fields = unnamed_fields.unnamed.iter().map(|f: &Field| {
-                let field_ty = &f.ty;
-                quote! {
-                        {
-                            let (v, s) = match drain.next() {
-                                Some((_key, value)) => {
+                .map(|(field_name, key, field_ty): (&Ident, String, &Type)| {
+                    quote! {
+                        #field_name: {
+                            let (v, s) = match captures.remove(#key) {
+                                Some(value) => {
                                     <#field_ty as ::yew_router::Switch>::from_route_part(
                                         ::yew_router::route::Route {
                                             route: value,
                                             state,
                                         }
                                     )
-                                },
+                                }
                                 None => {
                                     (
                                         <#field_ty as ::yew_router::Switch>::key_not_available(),
@@ -151,40 +93,96 @@ fn build_variant_from_captures(
                             }
                         }
                     }
+                })
+                .collect();
+
+            quote! {
+                let mut state = if let Some(mut captures) = matcher.capture_route_into_map(&route_string).ok().map(|x| x.1) {
+                    let create_item = || {
+                         (
+                            Some(
+                                #enum_ident::#variant_ident {
+                                    #(#fields),*
+                                }
+                            ),
+                            state
+                        )
+                    };
+                    let (val, state) = create_item();
+
+                    if val.is_some() {
+                        return (val, state);
+                    }
+                    state
+                } else {
+                    state
+                };
+            }
+        }
+        Fields::Unnamed(unnamed_fields) => {
+            let fields = unnamed_fields.unnamed.iter().map(|f: &Field| {
+                let field_ty = &f.ty;
+                quote! {
+                    {
+                        let (v, s) = match drain.next() {
+                            Some((_key, value)) => {
+                                <#field_ty as ::yew_router::Switch>::from_route_part(
+                                    ::yew_router::route::Route {
+                                        route: value,
+                                        state,
+                                    }
+                                )
+                            },
+                            None => {
+                                (
+                                    <#field_ty as ::yew_router::Switch>::key_not_available(),
+                                    state,
+                                )
+                            }
+                        };
+                        match v {
+                            Some(val) => {
+                                state = s; // Set state for the next var.
+                                val
+                            },
+                            None => return (None, s) // Failed
+                        }
+                    }
+                }
             });
 
             quote! {
-                    // TODO put an annotation here allowing unused muts.
-                    let mut state = if let Some(mut captures) = matcher.capture_route_into_vec(&route_string).ok().map(|x| x.1) {
-                        let mut drain = captures.drain(..);
-                        let create_item = || {
-                             (
-                                Some(
-                                    #enum_ident::#variant_ident(
-                                        #(#fields),*
-                                    )
-                                ),
-                                state
-                            )
-                        };
-                        let (val, state) = create_item();
-                        if val.is_some() {
-                            return (val, state);
-                        }
-                        state
-                    } else {
-                        state
+                // TODO put an annotation here allowing unused muts.
+                let mut state = if let Some(mut captures) = matcher.capture_route_into_vec(&route_string).ok().map(|x| x.1) {
+                    let mut drain = captures.drain(..);
+                    let create_item = || {
+                         (
+                            Some(
+                                #enum_ident::#variant_ident(
+                                    #(#fields),*
+                                )
+                            ),
+                            state
+                        )
                     };
-                }
+                    let (val, state) = create_item();
+                    if val.is_some() {
+                        return (val, state);
+                    }
+                    state
+                } else {
+                    state
+                };
+            }
         }
         Fields::Unit => {
             quote! {
-                    let mut state = if let Some(_captures) = matcher.capture_route_into_map(&route_string).ok().map(|x| x.1) {
-                        return (Some(#enum_ident::#variant_ident), state);
-                    } else {
-                        state
-                    };
-                }
+                let mut state = if let Some(_captures) = matcher.capture_route_into_map(&route_string).ok().map(|x| x.1) {
+                    return (Some(#enum_ident::#variant_ident), state);
+                } else {
+                    state
+                };
+            }
         }
     }
 }

--- a/crates/yew_router_macro/src/switch/shadow.rs
+++ b/crates/yew_router_macro/src/switch/shadow.rs
@@ -26,9 +26,9 @@ pub enum ShadowMatcherToken {
 }
 
 pub enum ShadowCaptureVariant {
-    Unnamed,                                         // {} - matches anything
-    ManyUnnamed,                                     // {*} - matches over multiple sections
-    NumberedUnnamed { sections: usize },             // {4} - matches 4 sections
+//    Unnamed,                                         // {} - matches anything
+//    ManyUnnamed,                                     // {*} - matches over multiple sections
+//    NumberedUnnamed { sections: usize },             // {4} - matches 4 sections
     Named(String), // {name} - captures a section and adds it to the map with a given name
     ManyNamed(String), // {*:name} - captures over many sections and adds it to the map with a given name.
     NumberedNamed { sections: usize, name: String }, // {2:name} - captures a fixed number of sections with a given name.
@@ -40,15 +40,15 @@ pub enum ShadowCaptureVariant {
 impl ToTokens for ShadowCaptureVariant {
     fn to_tokens(&self, ts: &mut TokenStream2) {
         let t = match self {
-            ShadowCaptureVariant::Unnamed => {
-                quote! {::yew_router::matcher::CaptureVariant::Unnamed}
-            }
-            ShadowCaptureVariant::ManyUnnamed => {
-                quote! {::yew_router::matcher::CaptureVariant::ManyUnnamed}
-            }
-            ShadowCaptureVariant::NumberedUnnamed { sections } => {
-                quote! {::yew_router::matcher::CaptureVariant::NumberedUnnamed{#sections}}
-            }
+//            ShadowCaptureVariant::Unnamed => {
+//                quote! {::yew_router::matcher::CaptureVariant::Unnamed}
+//            }
+//            ShadowCaptureVariant::ManyUnnamed => {
+//                quote! {::yew_router::matcher::CaptureVariant::ManyUnnamed}
+//            }
+//            ShadowCaptureVariant::NumberedUnnamed { sections } => {
+//                quote! {::yew_router::matcher::CaptureVariant::NumberedUnnamed{#sections}}
+//            }
             ShadowCaptureVariant::Named(name) => {
                 quote! {::yew_router::matcher::CaptureVariant::Named(#name.to_string())}
             }
@@ -79,9 +79,9 @@ impl From<CaptureVariant> for ShadowCaptureVariant {
         use CaptureVariant as CV;
         use ShadowCaptureVariant as SCV;
         match cv {
-            CV::Unnamed => SCV::Unnamed,
-            CaptureVariant::ManyUnnamed => SCV::ManyUnnamed,
-            CaptureVariant::NumberedUnnamed { sections } => SCV::NumberedUnnamed { sections },
+//            CV::Unnamed => SCV::Unnamed,
+//            CaptureVariant::ManyUnnamed => SCV::ManyUnnamed,
+//            CaptureVariant::NumberedUnnamed { sections } => SCV::NumberedUnnamed { sections },
             CaptureVariant::Named(name) => SCV::Named(name),
             CaptureVariant::ManyNamed(name) => SCV::ManyNamed(name),
             CaptureVariant::NumberedNamed { sections, name } => {

--- a/crates/yew_router_macro/src/switch/shadow.rs
+++ b/crates/yew_router_macro/src/switch/shadow.rs
@@ -1,7 +1,7 @@
 use quote::quote;
 use quote::ToTokens;
 use syn::export::TokenStream2;
-use yew_router_route_parser::{Capture, CaptureVariant, MatcherToken};
+use yew_router_route_parser::{CaptureVariant, MatcherToken};
 
 impl ToTokens for ShadowMatcherToken {
     fn to_tokens(&self, ts: &mut TokenStream2) {
@@ -26,9 +26,6 @@ pub enum ShadowMatcherToken {
 }
 
 pub enum ShadowCaptureVariant {
-//    Unnamed,                                         // {} - matches anything
-//    ManyUnnamed,                                     // {*} - matches over multiple sections
-//    NumberedUnnamed { sections: usize },             // {4} - matches 4 sections
     Named(String), // {name} - captures a section and adds it to the map with a given name
     ManyNamed(String), // {*:name} - captures over many sections and adds it to the map with a given name.
     NumberedNamed { sections: usize, name: String }, // {2:name} - captures a fixed number of sections with a given name.
@@ -67,7 +64,6 @@ impl From<MatcherToken> for ShadowMatcherToken {
 
 impl From<CaptureVariant> for ShadowCaptureVariant {
     fn from(cv: CaptureVariant) -> Self {
-        use CaptureVariant as CV;
         use ShadowCaptureVariant as SCV;
         match cv {
             CaptureVariant::Named(name) => SCV::Named(name),

--- a/crates/yew_router_macro/src/switch/shadow.rs
+++ b/crates/yew_router_macro/src/switch/shadow.rs
@@ -40,15 +40,6 @@ pub enum ShadowCaptureVariant {
 impl ToTokens for ShadowCaptureVariant {
     fn to_tokens(&self, ts: &mut TokenStream2) {
         let t = match self {
-//            ShadowCaptureVariant::Unnamed => {
-//                quote! {::yew_router::matcher::CaptureVariant::Unnamed}
-//            }
-//            ShadowCaptureVariant::ManyUnnamed => {
-//                quote! {::yew_router::matcher::CaptureVariant::ManyUnnamed}
-//            }
-//            ShadowCaptureVariant::NumberedUnnamed { sections } => {
-//                quote! {::yew_router::matcher::CaptureVariant::NumberedUnnamed{#sections}}
-//            }
             ShadowCaptureVariant::Named(name) => {
                 quote! {::yew_router::matcher::CaptureVariant::Named(#name.to_string())}
             }
@@ -79,9 +70,6 @@ impl From<CaptureVariant> for ShadowCaptureVariant {
         use CaptureVariant as CV;
         use ShadowCaptureVariant as SCV;
         match cv {
-//            CV::Unnamed => SCV::Unnamed,
-//            CaptureVariant::ManyUnnamed => SCV::ManyUnnamed,
-//            CaptureVariant::NumberedUnnamed { sections } => SCV::NumberedUnnamed { sections },
             CaptureVariant::Named(name) => SCV::Named(name),
             CaptureVariant::ManyNamed(name) => SCV::ManyNamed(name),
             CaptureVariant::NumberedNamed { sections, name } => {

--- a/crates/yew_router_macro/src/switch/shadow.rs
+++ b/crates/yew_router_macro/src/switch/shadow.rs
@@ -22,7 +22,7 @@ impl ToTokens for ShadowMatcherToken {
 /// It should match it exactly so that this macro can expand to the original.
 pub enum ShadowMatcherToken {
     Exact(String),
-    Capture(ShadowCapture),
+    Capture(ShadowCaptureVariant),
 }
 
 pub enum ShadowCaptureVariant {
@@ -34,38 +34,8 @@ pub enum ShadowCaptureVariant {
     NumberedNamed { sections: usize, name: String }, // {2:name} - captures a fixed number of sections with a given name.
 }
 
-pub struct ShadowCapture {
-    pub capture_variant: ShadowCaptureVariant,
-    pub allowed_captures: Option<Vec<String>>,
-}
 
-impl ToTokens for ShadowCapture {
-    fn to_tokens(&self, tokens: &mut TokenStream2) {
-        let ShadowCapture {
-            capture_variant,
-            allowed_captures,
-        } = self;
-        let t = match allowed_captures {
-            Some(allowed_captures) => {
-                quote! {
-                    ::yew_router::matcher::Capture {
-                        capture_variant: #capture_variant,
-                        allowed_captures: vec![#(#allowed_captures),*]
-                    }
-                }
-            }
-            None => {
-                quote! {
-                    ::yew_router::matcher::Capture {
-                        capture_variant: #capture_variant,
-                        allowed_captures: None
-                    }
-                }
-            }
-        };
-        tokens.extend(t)
-    }
-}
+
 
 impl ToTokens for ShadowCaptureVariant {
     fn to_tokens(&self, ts: &mut TokenStream2) {
@@ -121,11 +91,3 @@ impl From<CaptureVariant> for ShadowCaptureVariant {
     }
 }
 
-impl From<Capture> for ShadowCapture {
-    fn from(c: Capture) -> Self {
-        ShadowCapture {
-            capture_variant: c.capture_variant.into(),
-            allowed_captures: c.allowed_captures,
-        }
-    }
-}

--- a/crates/yew_router_macro/src/switch/shadow.rs
+++ b/crates/yew_router_macro/src/switch/shadow.rs
@@ -13,9 +13,6 @@ impl ToTokens for ShadowMatcherToken {
             SOT::Capture(variant) => quote! {
                 ::yew_router::matcher::MatcherToken::Capture(#variant)
             },
-            SOT::Optional(optional) => quote! {
-                ::yew_router::matcher::MatcherToken::Optional(vec![#(#optional),*])
-            },
         };
         ts.extend(t)
     }
@@ -26,7 +23,6 @@ impl ToTokens for ShadowMatcherToken {
 pub enum ShadowMatcherToken {
     Exact(String),
     Capture(ShadowCapture),
-    Optional(Vec<ShadowMatcherToken>),
 }
 
 pub enum ShadowCaptureVariant {
@@ -104,7 +100,6 @@ impl From<MatcherToken> for ShadowMatcherToken {
         match ot {
             MT::Exact(s) => SOT::Exact(s),
             MT::Capture(capture) => SOT::Capture(capture.into()),
-            MT::Optional(optional) => SOT::Optional(optional.into_iter().map(SOT::from).collect()),
         }
     }
 }

--- a/crates/yew_router_macro/src/switch/shadow.rs
+++ b/crates/yew_router_macro/src/switch/shadow.rs
@@ -31,9 +31,6 @@ pub enum ShadowCaptureVariant {
     NumberedNamed { sections: usize, name: String }, // {2:name} - captures a fixed number of sections with a given name.
 }
 
-
-
-
 impl ToTokens for ShadowCaptureVariant {
     fn to_tokens(&self, ts: &mut TokenStream2) {
         let t = match self {
@@ -74,4 +71,3 @@ impl From<CaptureVariant> for ShadowCaptureVariant {
         }
     }
 }
-

--- a/crates/yew_router_route_parser/src/lib.rs
+++ b/crates/yew_router_route_parser/src/lib.rs
@@ -15,7 +15,7 @@ pub mod parser;
 mod token_optimizer;
 
 pub use parser::{Capture, CaptureVariant};
-use std::collections::{HashMap};
+use std::collections::HashMap;
 pub use token_optimizer::{
     next_delimiters, optimize_tokens, parse_str_and_optimize_tokens, MatcherToken,
 };

--- a/crates/yew_router_route_parser/src/parser/core.rs
+++ b/crates/yew_router_route_parser/src/parser/core.rs
@@ -68,13 +68,13 @@ pub fn capture(i: &str) -> IResult<&str, RouteParserToken, VerboseError<&str>> {
     // Capture the variant.
     let capture_variants = alt((
         // This can be terminated by either the end of the match section, or by the beginning of a allowed_matches section.
-        map(peek(alt((char('}'), char('(')))), |_| {
-            CaptureVariant::Unnamed
-        }),
+//        map(peek(alt((char('}'), char('(')))), |_| {
+//            CaptureVariant::Unnamed
+//        }),
         map(preceded(tag("*:"), valid_ident_characters), |s| {
             CaptureVariant::ManyNamed(s.to_string())
         }),
-        map(char('*'), |_| CaptureVariant::ManyUnnamed),
+//        map(char('*'), |_| CaptureVariant::ManyUnnamed),
         map(valid_ident_characters, |s| {
             CaptureVariant::Named(s.to_string())
         }),
@@ -85,9 +85,9 @@ pub fn capture(i: &str) -> IResult<&str, RouteParserToken, VerboseError<&str>> {
                 name: s.to_string(),
             },
         ),
-        map(digit1, |num: &str| CaptureVariant::NumberedUnnamed {
-            sections: num.parse().expect("should parse digits"),
-        }),
+//        map(digit1, |num: &str| CaptureVariant::NumberedUnnamed {
+//            sections: num.parse().expect("should parse digits"),
+//        }),
     ));
 
     let allowed_matches = map(

--- a/crates/yew_router_route_parser/src/parser/core.rs
+++ b/crates/yew_router_route_parser/src/parser/core.rs
@@ -49,32 +49,16 @@ pub fn match_exact(i: &str) -> IResult<&str, RouteParserToken, VerboseError<&str
 
 /// Matches any of the capture variants
 ///
-/// * {}
-/// * {*}
-/// * {5}
 /// * {name}
 /// * {*:name}
 /// * {5:name}
-/// With optional specification of exact matches.
-///
-///
-/// * {(yes|no)}
-/// * {*(yes|no)}
-/// * {5(yes|no)}
-/// * {name(yes|no)}
-/// * {*:name(yes|no)}
-/// * {5:name(yes|no)}
 pub fn capture(i: &str) -> IResult<&str, RouteParserToken, VerboseError<&str>> {
     // Capture the variant.
     let capture_variants = alt((
         // This can be terminated by either the end of the match section, or by the beginning of a allowed_matches section.
-//        map(peek(alt((char('}'), char('(')))), |_| {
-//            CaptureVariant::Unnamed
-//        }),
         map(preceded(tag("*:"), valid_ident_characters), |s| {
             CaptureVariant::ManyNamed(s.to_string())
         }),
-//        map(char('*'), |_| CaptureVariant::ManyUnnamed),
         map(valid_ident_characters, |s| {
             CaptureVariant::Named(s.to_string())
         }),
@@ -85,9 +69,6 @@ pub fn capture(i: &str) -> IResult<&str, RouteParserToken, VerboseError<&str>> {
                 name: s.to_string(),
             },
         ),
-//        map(digit1, |num: &str| CaptureVariant::NumberedUnnamed {
-//            sections: num.parse().expect("should parse digits"),
-//        }),
     ));
 
     let allowed_matches = map(
@@ -234,10 +215,5 @@ mod test {
     #[test]
     fn capture_consumes() {
         capture("{aoeu").expect_err("Should not complete");
-    }
-
-    #[test]
-    fn can_specify_exact_match_option() {
-        capture("{(lorem|ipsum)}").expect("Should complete");
     }
 }

--- a/crates/yew_router_route_parser/src/parser/core.rs
+++ b/crates/yew_router_route_parser/src/parser/core.rs
@@ -113,15 +113,6 @@ mod test {
     use super::*;
 
     #[test]
-    fn match_any() {
-        let cap = capture("{}").expect("Should match").1;
-        assert_eq!(
-            cap,
-            RouteParserToken::Capture(Capture::from(CaptureVariant::Unnamed))
-        );
-    }
-
-    #[test]
     fn capture_named_test() {
         let cap = capture("{loremipsum}").unwrap();
         assert_eq!(
@@ -131,18 +122,6 @@ mod test {
                 RouteParserToken::Capture(Capture::from(CaptureVariant::Named(
                     "loremipsum".to_string()
                 )))
-            )
-        );
-    }
-
-    #[test]
-    fn capture_many_unnamed_test() {
-        let cap = capture("{*}").unwrap();
-        assert_eq!(
-            cap,
-            (
-                "",
-                RouteParserToken::Capture(Capture::from(CaptureVariant::ManyUnnamed))
             )
         );
     }

--- a/crates/yew_router_route_parser/src/parser/core.rs
+++ b/crates/yew_router_route_parser/src/parser/core.rs
@@ -126,31 +126,6 @@ mod test {
         );
     }
 
-    #[test]
-    fn capture_unnamed_test() {
-        let cap = capture("{}").unwrap();
-        assert_eq!(
-            cap,
-            (
-                "",
-                RouteParserToken::Capture(Capture::from(CaptureVariant::Unnamed))
-            )
-        );
-    }
-
-    #[test]
-    fn capture_numbered_unnamed_test() {
-        let cap = capture("{5}").unwrap();
-        assert_eq!(
-            cap,
-            (
-                "",
-                RouteParserToken::Capture(Capture::from(CaptureVariant::NumberedUnnamed {
-                    sections: 5
-                }))
-            )
-        );
-    }
 
     #[test]
     fn capture_numbered_named_test() {

--- a/crates/yew_router_route_parser/src/parser/mod.rs
+++ b/crates/yew_router_route_parser/src/parser/mod.rs
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn can_match_in_first_section_1() {
-        parse("{*}").expect("Should validate");
+        parse("{*:lorem}").expect("Should validate");
     }
 
     #[test]

--- a/crates/yew_router_route_parser/src/parser/mod.rs
+++ b/crates/yew_router_route_parser/src/parser/mod.rs
@@ -53,15 +53,6 @@ pub enum RouteParserToken {
 /// It can capture and discard for unnamed variants, or capture and store in the `Matches` for the named variants.
 #[derive(Debug, Clone, PartialEq)]
 pub enum CaptureVariant {
-    /// {} - matches anything.
-    Unnamed,
-    /// {*} - matches over multiple sections.
-    ManyUnnamed,
-    /// {4} - matches 4 sections.
-    NumberedUnnamed {
-        /// Number of sections to match.
-        sections: usize,
-    },
     /// {name} - captures a section and adds it to the map with a given name.
     Named(String),
     /// {*:name} - captures over many sections and adds it to the map with a given name.

--- a/crates/yew_router_route_parser/src/parser/mod.rs
+++ b/crates/yew_router_route_parser/src/parser/mod.rs
@@ -188,7 +188,7 @@ mod tests {
 
     #[test]
     fn parse_can_handle_multiple_matches_per_section() {
-        let parsed = parse("/lorem/{ipsum}dolor{}").expect("should parse");
+        let parsed = parse("/lorem/{ipsum}dolor{sit}").expect("should parse");
         assert_eq!(
             parsed,
             vec![
@@ -199,7 +199,7 @@ mod tests {
                     "ipsum".to_string()
                 ))),
                 RouteParserToken::Exact("dolor".to_string()),
-                RouteParserToken::Capture(Capture::from(CaptureVariant::Unnamed))
+                RouteParserToken::Capture(Capture::from(CaptureVariant::Named("sit".to_string())))
             ]
         )
     }

--- a/crates/yew_router_route_parser/src/parser/path.rs
+++ b/crates/yew_router_route_parser/src/parser/path.rs
@@ -150,7 +150,7 @@ mod test {
         let e = all_consuming(path_parser)("/path{}{match}").expect_err("Should not validate");
         assert_eq!(
             e,
-            Err::Error(VerboseError::from_error_kind("{match}", ErrorKind::Eof))
+            Err::Error(VerboseError::from_error_kind("{}{match}", ErrorKind::Eof))
         )
     }
 
@@ -169,7 +169,7 @@ mod test {
         let e = all_consuming(path_parser)("/path{}{}").expect_err("Should not validate");
         assert_eq!(
             e,
-            Err::Error(VerboseError::from_error_kind("{}", ErrorKind::Eof))
+            Err::Error(VerboseError::from_error_kind("{}{}", ErrorKind::Eof))
         )
     }
 
@@ -237,37 +237,7 @@ mod test {
         assert_eq!(tokens, expected);
     }
 
-    #[test]
-    fn option_section_between_capture_then_exact() {
-        let (_, tokens) = path_parser("/first[/{}]/third").expect("Should validate");
-        let expected = vec![
-            RouteParserToken::Separator,
-            RouteParserToken::Exact("first".to_string()),
-            RouteParserToken::Optional(vec![
-                RouteParserToken::Separator,
-                RouteParserToken::Capture(Capture::from(CaptureVariant::Named("Lorem".to_string()))),
-            ]),
-            RouteParserToken::Separator,
-            RouteParserToken::Exact("third".to_string()),
-        ];
-        assert_eq!(tokens, expected);
-    }
 
-    #[test]
-    fn option_section_between_exact_then_capture() {
-        let (_, tokens) = path_parser("/first[/second]/{}").expect("Should validate");
-        let expected = vec![
-            RouteParserToken::Separator,
-            RouteParserToken::Exact("first".to_string()),
-            RouteParserToken::Optional(vec![
-                RouteParserToken::Separator,
-                RouteParserToken::Exact("second".to_string()),
-            ]),
-            RouteParserToken::Separator,
-            RouteParserToken::Capture(Capture::from(CaptureVariant::Named("Lorem".to_string()))),
-        ];
-        assert_eq!(tokens, expected);
-    }
 
     #[test]
     fn option_section_between_captures_fails() {

--- a/crates/yew_router_route_parser/src/parser/path.rs
+++ b/crates/yew_router_route_parser/src/parser/path.rs
@@ -245,7 +245,7 @@ mod test {
             RouteParserToken::Exact("first".to_string()),
             RouteParserToken::Optional(vec![
                 RouteParserToken::Separator,
-                RouteParserToken::Capture(Capture::from(CaptureVariant::Unnamed)),
+                RouteParserToken::Capture(Capture::from(CaptureVariant::Named("Lorem".to_string()))),
             ]),
             RouteParserToken::Separator,
             RouteParserToken::Exact("third".to_string()),
@@ -264,7 +264,7 @@ mod test {
                 RouteParserToken::Exact("second".to_string()),
             ]),
             RouteParserToken::Separator,
-            RouteParserToken::Capture(Capture::from(CaptureVariant::Unnamed)),
+            RouteParserToken::Capture(Capture::from(CaptureVariant::Named("Lorem".to_string()))),
         ];
         assert_eq!(tokens, expected);
     }

--- a/crates/yew_router_route_parser/src/token_optimizer.rs
+++ b/crates/yew_router_route_parser/src/token_optimizer.rs
@@ -42,12 +42,6 @@ pub fn next_delimiters<'a>(
     enum MatchOrOptSequence<'a> {
         Match(&'a str),
     }
-//    fn search_for_inner_sequence(matcher_token: &MatcherToken) -> Option<&str> {
-//        match matcher_token {
-//            MatcherToken::Exact(sequence) => Some(&sequence),
-//            MatcherToken::Capture(_) => None, // TODO still may want to handle this
-//        }
-//    }
 
     let mut sequences = vec![];
     for next in iter {
@@ -190,7 +184,7 @@ mod test {
             RouteParserToken::Separator,
             RouteParserToken::Exact("thing".to_string()),
         ];
-        let optimized = optimize_tokens(tokens, true);
+        let optimized = optimize_tokens(tokens);
         let expected = vec![
             MatcherToken::Exact("/thing".to_string()),
             MatcherToken::Optional(vec![MatcherToken::Exact("/".to_string())]),
@@ -209,7 +203,7 @@ mod test {
                 capture_or_match: CaptureOrExact::Exact("GeneralKenobi".to_string()),
             },
         ];
-        let optimized = optimize_tokens(tokens, true);
+        let optimized = optimize_tokens(tokens);
         let expected = vec![
             MatcherToken::Exact("/thing".to_string()),
             MatcherToken::Optional(vec![MatcherToken::Exact("/".to_string())]),
@@ -225,7 +219,7 @@ mod test {
             RouteParserToken::Exact("thing".to_string()),
             RouteParserToken::FragmentBegin,
         ];
-        let optimized = optimize_tokens(tokens, true);
+        let optimized = optimize_tokens(tokens);
         let expected = vec![
             MatcherToken::Exact("/thing".to_string()),
             MatcherToken::Optional(vec![MatcherToken::Exact("/".to_string())]),
@@ -241,7 +235,7 @@ mod test {
             RouteParserToken::Exact("thing".to_string()),
             RouteParserToken::Separator,
         ];
-        let optimized = optimize_tokens(tokens, true);
+        let optimized = optimize_tokens(tokens);
         let expected = vec![MatcherToken::Exact("/thing/".to_string())];
         assert_eq!(expected, optimized);
     }
@@ -256,7 +250,7 @@ mod test {
                 RouteParserToken::Exact("lorem".to_string()),
             ]),
         ];
-        let optimized = optimize_tokens(tokens, false);
+        let optimized = optimize_tokens(tokens);
         let expected = vec![
             MatcherToken::Exact("/lorem".to_string()),
             MatcherToken::Optional(vec![MatcherToken::Exact("/lorem".to_string())]),
@@ -274,7 +268,7 @@ mod test {
                 RouteParserToken::Exact("lorem".to_string()),
             ]),
         ];
-        let optimized = optimize_tokens(tokens, true);
+        let optimized = optimize_tokens(tokens);
         let expected = vec![
             MatcherToken::Exact("/lorem".to_string()),
             MatcherToken::Optional(vec![MatcherToken::Exact("/lorem".to_string())]),
@@ -288,7 +282,7 @@ mod test {
         let tokens = vec![RouteParserToken::Capture(Capture::from(
             CaptureVariant::ManyNamed("lorem".to_string()),
         ))];
-        let optimized = optimize_tokens(tokens, true);
+        let optimized = optimize_tokens(tokens);
         let expected = vec![MatcherToken::Capture(CaptureVariant::ManyNamed(
             "lorem".to_string(),
         ))];
@@ -303,7 +297,7 @@ mod test {
                 "lorem".to_string(),
             ))),
         ];
-        let optimized = optimize_tokens(tokens, true);
+        let optimized = optimize_tokens(tokens);
         let expected = vec![
             MatcherToken::Exact("/".to_string()),
             MatcherToken::Capture(CaptureVariant::ManyNamed("lorem".to_string())),
@@ -320,7 +314,7 @@ mod test {
                 capture_or_match: CaptureOrExact::Capture(Capture::from(CaptureVariant::Unnamed)),
             },
         ];
-        let optimized = optimize_tokens(tokens, true);
+        let optimized = optimize_tokens(tokens);
         let expected = vec![
             MatcherToken::Exact("?lorem=".to_string()),
             MatcherToken::Capture(CaptureVariant::Unnamed),

--- a/crates/yew_router_route_parser/src/token_optimizer.rs
+++ b/crates/yew_router_route_parser/src/token_optimizer.rs
@@ -1,6 +1,6 @@
 use crate::parser::parse;
 use crate::parser::RouteParserToken;
-use crate::parser::{Capture, CaptureOrExact};
+use crate::parser::{CaptureOrExact};
 use nom::IResult;
 use std::iter::Peekable;
 use std::slice::Iter;
@@ -8,8 +8,7 @@ use std::slice::Iter;
 use crate::parser::util::alternative;
 use crate::parser::YewRouterParseError;
 use crate::CaptureVariant;
-use nom::branch::alt;
-use nom::combinator::{cond, map, map_opt, rest};
+use nom::combinator::{map, };
 
 /// Tokens used to determine how to match and capture sections from a URL.
 #[derive(Debug, PartialEq, Clone)]
@@ -43,12 +42,12 @@ pub fn next_delimiters<'a>(
     enum MatchOrOptSequence<'a> {
         Match(&'a str),
     }
-    fn search_for_inner_sequence(matcher_token: &MatcherToken) -> Option<&str> {
-        match matcher_token {
-            MatcherToken::Exact(sequence) => Some(&sequence),
-            MatcherToken::Capture(_) => None, // TODO still may want to handle this
-        }
-    }
+//    fn search_for_inner_sequence(matcher_token: &MatcherToken) -> Option<&str> {
+//        match matcher_token {
+//            MatcherToken::Exact(sequence) => Some(&sequence),
+//            MatcherToken::Capture(_) => None, // TODO still may want to handle this
+//        }
+//    }
 
     let mut sequences = vec![];
     for next in iter {
@@ -92,6 +91,7 @@ fn token_to_string(token: &RouteParserToken) -> &str {
     }
 }
 
+
 /// Parse the provided "matcher string" and then optimize the tokens.
 pub fn parse_str_and_optimize_tokens(i: &str) -> Result<Vec<MatcherToken>, YewRouterParseError> {
     let tokens = parse(i)?;
@@ -110,21 +110,19 @@ pub fn optimize_tokens(tokens: Vec<RouteParserToken>) -> Vec<MatcherToken> {
     // Stores consecutive Tokens that can be reduced down to a OptimizedToken::Match.
     let mut run: Vec<RouteParserToken> = vec![];
 
-    let mut fragment_or_query_encountered = false;
 
     let mut token_iterator = tokens.into_iter().peekable();
 
     while let Some(token) = token_iterator.next() {
         match &token {
             RouteParserToken::QueryBegin | RouteParserToken::FragmentBegin => {
-                fragment_or_query_encountered = true;
                 run.push(token)
             }
             RouteParserToken::Separator | RouteParserToken::QuerySeparator => run.push(token),
             RouteParserToken::Exact(_) => {
                 run.push(token);
             }
-            RouteParserToken::Optional(tokens) => panic!("Optionals being removed"),
+            RouteParserToken::Optional(_tokens) => panic!("Optionals being removed"),
             RouteParserToken::Capture(variant) => {
                 // Empty the run when a capture is encountered.
                 if !run.is_empty() {
@@ -160,12 +158,12 @@ pub fn optimize_tokens(tokens: Vec<RouteParserToken>) -> Vec<MatcherToken> {
     optimized
 }
 
-fn token_is_not_present_or_is_either_a_slash_or_question(token: Option<&RouteParserToken>) -> bool {
-    match token {
-        None | Some(RouteParserToken::QueryBegin) | Some(RouteParserToken::FragmentBegin) => true,
-        _ => false,
-    }
-}
+//fn token_is_not_present_or_is_either_a_slash_or_question(token: Option<&RouteParserToken>) -> bool {
+//    match token {
+//        None | Some(RouteParserToken::QueryBegin) | Some(RouteParserToken::FragmentBegin) => true,
+//        _ => false,
+//    }
+//}
 
 #[cfg(test)]
 mod test {

--- a/crates/yew_router_route_parser/src/token_optimizer.rs
+++ b/crates/yew_router_route_parser/src/token_optimizer.rs
@@ -9,6 +9,7 @@ use crate::parser::util::alternative;
 use crate::parser::YewRouterParseError;
 use nom::branch::alt;
 use nom::combinator::{cond, map_opt, rest, map};
+use crate::CaptureVariant;
 
 /// Tokens used to determine how to match and capture sections from a URL.
 #[derive(Debug, PartialEq, Clone)]
@@ -16,14 +17,14 @@ pub enum MatcherToken {
     /// Section-related tokens can be condensed into a match.
     Exact(String),
     /// Capture section.
-    Capture(Capture),
+    Capture(CaptureVariant),
 }
 
 impl From<CaptureOrExact> for MatcherToken {
     fn from(value: CaptureOrExact) -> Self {
         match value {
             CaptureOrExact::Exact(m) => MatcherToken::Exact(m),
-            CaptureOrExact::Capture(v) => MatcherToken::Capture(v),
+            CaptureOrExact::Capture(v) => MatcherToken::Capture(v.capture_variant),
         }
     }
 }
@@ -142,7 +143,7 @@ pub fn optimize_tokens(
                     optimized.push(MatcherToken::Exact(s));
                     run.clear()
                 }
-                optimized.push(MatcherToken::Capture(variant.clone()))
+                optimized.push(MatcherToken::Capture(variant.capture_variant.clone()))
             }
             RouteParserToken::QueryCapture {
                 ident,
@@ -156,7 +157,7 @@ pub fn optimize_tokens(
                         optimized.push(MatcherToken::Exact(s));
                         run.clear();
 
-                        optimized.push(MatcherToken::Capture(capture.clone()))
+                        optimized.push(MatcherToken::Capture(capture.capture_variant.clone()))
                     }
                 }
             }
@@ -195,7 +196,7 @@ mod test {
         )));
         assert_eq!(
             mt,
-            MatcherToken::Capture(Capture::from(CaptureVariant::Unnamed))
+            MatcherToken::Capture(aptureVariant::Unnamed)
         )
     }
 

--- a/crates/yew_router_route_parser/src/token_optimizer.rs
+++ b/crates/yew_router_route_parser/src/token_optimizer.rs
@@ -7,9 +7,9 @@ use std::slice::Iter;
 //use nom::bytes::complete::take_till1;
 use crate::parser::util::alternative;
 use crate::parser::YewRouterParseError;
-use nom::branch::alt;
-use nom::combinator::{cond, map_opt, rest, map};
 use crate::CaptureVariant;
+use nom::branch::alt;
+use nom::combinator::{cond, map, map_opt, rest};
 
 /// Tokens used to determine how to match and capture sections from a URL.
 #[derive(Debug, PartialEq, Clone)]
@@ -75,10 +75,7 @@ pub fn next_delimiters<'a>(
     );
 
     // if the sequence contains an optional section, it can attempt to match until the end.
-    map(
-             alternative(delimiters),
-        |x| x,
-    )
+    map(alternative(delimiters), |x| x)
 }
 
 /// Tokens that can be coalesced to a OptimizedToken::Match are converted to strings here.
@@ -96,13 +93,10 @@ fn token_to_string(token: &RouteParserToken) -> &str {
 }
 
 /// Parse the provided "matcher string" and then optimize the tokens.
-pub fn parse_str_and_optimize_tokens(
-    i: &str,
-) -> Result<Vec<MatcherToken>, YewRouterParseError> {
+pub fn parse_str_and_optimize_tokens(i: &str) -> Result<Vec<MatcherToken>, YewRouterParseError> {
     let tokens = parse(i)?;
     Ok(optimize_tokens(tokens))
 }
-
 
 /// Optimize `RouteParserToken`s to `MatcherToken`s.
 ///
@@ -110,9 +104,7 @@ pub fn parse_str_and_optimize_tokens(
 /// For example, the tokens \[Separator, Match("thing"), Separator\] becomes just \[Match("/thing/")\].
 ///
 /// It also if configured to do so, will add optional slashes at the end of path sections where appropriate.
-pub fn optimize_tokens(
-    tokens: Vec<RouteParserToken>,
-) -> Vec<MatcherToken> {
+pub fn optimize_tokens(tokens: Vec<RouteParserToken>) -> Vec<MatcherToken> {
     // The list of optimized tokens.
     let mut optimized: Vec<MatcherToken> = vec![];
     // Stores consecutive Tokens that can be reduced down to a OptimizedToken::Match.
@@ -132,9 +124,7 @@ pub fn optimize_tokens(
             RouteParserToken::Exact(_) => {
                 run.push(token);
             }
-            RouteParserToken::Optional(tokens) => {
-                panic!("Optionals being removed")
-            }
+            RouteParserToken::Optional(tokens) => panic!("Optionals being removed"),
             RouteParserToken::Capture(variant) => {
                 // Empty the run when a capture is encountered.
                 if !run.is_empty() {
@@ -193,10 +183,7 @@ mod test {
         let mt = MatcherToken::from(CaptureOrExact::Capture(Capture::from(
             CaptureVariant::Unnamed,
         )));
-        assert_eq!(
-            mt,
-            MatcherToken::Capture(aptureVariant::Unnamed)
-        )
+        assert_eq!(mt, MatcherToken::Capture(aptureVariant::Unnamed))
     }
 
     #[test]
@@ -304,9 +291,9 @@ mod test {
             CaptureVariant::ManyNamed("lorem".to_string()),
         ))];
         let optimized = optimize_tokens(tokens, true);
-        let expected = vec![MatcherToken::Capture(
-            CaptureVariant::ManyNamed("lorem".to_string()),
-        )];
+        let expected = vec![MatcherToken::Capture(CaptureVariant::ManyNamed(
+            "lorem".to_string(),
+        ))];
         assert_eq!(expected, optimized);
     }
 
@@ -321,9 +308,7 @@ mod test {
         let optimized = optimize_tokens(tokens, true);
         let expected = vec![
             MatcherToken::Exact("/".to_string()),
-            MatcherToken::Capture(CaptureVariant::ManyNamed(
-                "lorem".to_string(),
-            )),
+            MatcherToken::Capture(CaptureVariant::ManyNamed("lorem".to_string())),
         ];
         assert_eq!(expected, optimized);
     }

--- a/crates/yew_router_route_parser/src/token_optimizer.rs
+++ b/crates/yew_router_route_parser/src/token_optimizer.rs
@@ -305,9 +305,9 @@ mod test {
             CaptureVariant::ManyNamed("lorem".to_string()),
         ))];
         let optimized = optimize_tokens(tokens, true);
-        let expected = vec![MatcherToken::Capture(Capture::from(
+        let expected = vec![MatcherToken::Capture(
             CaptureVariant::ManyNamed("lorem".to_string()),
-        ))];
+        )];
         assert_eq!(expected, optimized);
     }
 
@@ -322,9 +322,9 @@ mod test {
         let optimized = optimize_tokens(tokens, true);
         let expected = vec![
             MatcherToken::Exact("/".to_string()),
-            MatcherToken::Capture(Capture::from(CaptureVariant::ManyNamed(
+            MatcherToken::Capture(CaptureVariant::ManyNamed(
                 "lorem".to_string(),
-            ))),
+            )),
         ];
         assert_eq!(expected, optimized);
     }
@@ -341,7 +341,7 @@ mod test {
         let optimized = optimize_tokens(tokens, true);
         let expected = vec![
             MatcherToken::Exact("?lorem=".to_string()),
-            MatcherToken::Capture(Capture::from(CaptureVariant::Unnamed)),
+            MatcherToken::Capture(CaptureVariant::Unnamed),
         ];
         assert_eq!(expected, optimized);
     }

--- a/crates/yew_router_route_parser/src/token_optimizer.rs
+++ b/crates/yew_router_route_parser/src/token_optimizer.rs
@@ -98,11 +98,11 @@ fn token_to_string(token: &RouteParserToken) -> &str {
 /// Parse the provided "matcher string" and then optimize the tokens.
 pub fn parse_str_and_optimize_tokens(
     i: &str,
-    append_optional_slash: bool,
 ) -> Result<Vec<MatcherToken>, YewRouterParseError> {
     let tokens = parse(i)?;
-    Ok(optimize_tokens(tokens, append_optional_slash))
+    Ok(optimize_tokens(tokens))
 }
+
 
 /// Optimize `RouteParserToken`s to `MatcherToken`s.
 ///
@@ -112,7 +112,6 @@ pub fn parse_str_and_optimize_tokens(
 /// It also if configured to do so, will add optional slashes at the end of path sections where appropriate.
 pub fn optimize_tokens(
     tokens: Vec<RouteParserToken>,
-    append_optional_slash: bool,
 ) -> Vec<MatcherToken> {
     // The list of optimized tokens.
     let mut optimized: Vec<MatcherToken> = vec![];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ pub use crate::route::RouteState;
 pub use crate::router::RouterState;
 
 pub mod switch;
-pub use switch::{Switch};
+pub use switch::Switch;
 pub use yew_router_macro::Switch;
 
 /// The route macro produces a Matcher which can be used to determine if a route string should cause

--- a/src/matcher/route_matcher/match_paths.rs
+++ b/src/matcher/route_matcher/match_paths.rs
@@ -274,7 +274,7 @@ mod integration_test {
 
     #[test]
     fn match_query_after_path() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/a/path?lorem=ipsum", true)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/a/path?lorem=ipsum")
             .expect("Should parse");
         match_path_impl(&x, MatcherSettings::default(), "/a/path?lorem=ipsum")
             .expect("should match");
@@ -283,7 +283,7 @@ mod integration_test {
     #[test]
     fn match_query_after_path_trailing_slash() {
         let x =
-            yew_router_route_parser::parse_str_and_optimize_tokens("/a/path/?lorem=ipsum", true)
+            yew_router_route_parser::parse_str_and_optimize_tokens("/a/path/?lorem=ipsum")
                 .expect("Should parse");
         match_path_impl(&x, MatcherSettings::default(), "/a/path/?lorem=ipsum")
             .expect("should match");
@@ -299,14 +299,14 @@ mod integration_test {
 
     #[test]
     fn match_query() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("?lorem=ipsum", true)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("?lorem=ipsum")
             .expect("Should parse");
         match_path_impl(&x, MatcherSettings::default(), "?lorem=ipsum").expect("should match");
     }
 
     #[test]
     fn named_capture_query() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("?lorem={ipsum}", true)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("?lorem={ipsum}")
             .expect("Should parse");
         let (_, matches) =
             match_path_impl(&x, MatcherSettings::default(), "?lorem=ipsum").expect("should match");
@@ -315,14 +315,14 @@ mod integration_test {
 
     #[test]
     fn match_n_paths_1() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{*}", true)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{*}" )
             .expect("Should parse");
         match_path_impl(&x, MatcherSettings::default(), "/anything").expect("should match");
     }
 
     #[test]
     fn match_n_paths_2() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{*}", true)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{*}")
             .expect("Should parse");
         match_path_impl(&x, MatcherSettings::default(), "/anything/other/thing")
             .expect("should match");
@@ -330,7 +330,7 @@ mod integration_test {
 
     #[test]
     fn match_n_paths_3() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{*:cap}/thing", true)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{*:cap}/thing")
             .expect("Should parse");
         let matches = match_path_impl(&x, MatcherSettings::default(), "/anything/other/thing")
             .expect("should match")
@@ -340,7 +340,7 @@ mod integration_test {
 
     #[test]
     fn match_n_paths_4() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{*:cap}/thing", true)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{*:cap}/thing")
             .expect("Should parse");
         let matches = match_path_impl(&x, MatcherSettings::default(), "/anything/thing/thing")
             .expect("should match")
@@ -350,7 +350,7 @@ mod integration_test {
 
     #[test]
     fn match_path_5() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{cap}/thing", true)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{cap}/thing")
             .expect("Should parse");
         let matches = match_path_impl(&x, MatcherSettings::default(), "/anything/thing/thing")
             .expect("should match")
@@ -360,21 +360,21 @@ mod integration_test {
 
     #[test]
     fn match_fragment() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("#test", true)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("#test")
             .expect("Should parse");
         match_path_impl(&x, MatcherSettings::default(), "#test").expect("should match");
     }
 
     #[test]
     fn match_fragment_after_path() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/a/path/#test", true)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/a/path/#test")
             .expect("Should parse");
         match_path_impl(&x, MatcherSettings::default(), "/a/path/#test").expect("should match");
     }
 
     #[test]
     fn match_fragment_after_path_no_slash() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/a/path#test", true)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/a/path#test")
             .expect("Should parse");
         match_path_impl(&x, MatcherSettings::default(), "/a/path#test").expect("should match");
     }
@@ -383,7 +383,6 @@ mod integration_test {
     fn match_fragment_after_query() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens(
             "/a/path?query=thing#test",
-            true,
         )
         .expect("Should parse");
         match_path_impl(&x, MatcherSettings::default(), "/a/path?query=thing#test")
@@ -394,7 +393,6 @@ mod integration_test {
     fn match_fragment_after_query_capture() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens(
             "/a/path?query={capture}#test",
-            true,
         )
         .expect("Should parse");
         match_path_impl(&x, MatcherSettings::default(), "/a/path?query=thing#test")
@@ -403,14 +401,14 @@ mod integration_test {
 
     #[test]
     fn match_fragment_optional() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("[#test]", true)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("[#test]")
             .expect("Should parse");
         match_path_impl(&x, MatcherSettings::default(), "#test").expect("should match");
         match_path_impl(&x, MatcherSettings::default(), "").expect("should match");
     }
     #[test]
     fn match_fragment_pound_optional() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("#[test]", true)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("#[test]")
             .expect("Should parse");
         match_path_impl(&x, MatcherSettings::default(), "#test").expect("should match");
         match_path_impl(&x, MatcherSettings::default(), "#").expect("should match");
@@ -418,7 +416,7 @@ mod integration_test {
 
     #[test]
     fn match_fragment_optional_with_inner_optional_item() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("[#[test]]", true)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("[#[test]]")
             .expect("Should parse");
         match_path_impl(&x, MatcherSettings::default(), "#test").expect("should match");
         match_path_impl(&x, MatcherSettings::default(), "").expect("should match");
@@ -427,7 +425,7 @@ mod integration_test {
 
     #[test]
     fn capture_as_only_token() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("{any}", true)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("{any}")
             .expect("Should parse");
         match_path_impl(&x, MatcherSettings::default(), "literally_anything")
             .expect("should match");
@@ -435,7 +433,7 @@ mod integration_test {
 
     #[test]
     fn optional_path_first() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("[/thing]", true)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("[/thing]")
             .expect("Should parse");
         match_path_impl(&x, MatcherSettings::default(), "").expect("should match");
         match_path_impl(&x, MatcherSettings::default(), "/thing").expect("should match");
@@ -443,7 +441,7 @@ mod integration_test {
 
     #[test]
     fn optional_path_after_item() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/first[/second]", true)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/first[/second]")
             .expect("Should parse");
         assert_eq!(
             x,
@@ -459,7 +457,7 @@ mod integration_test {
 
     #[test]
     fn optional_path_any() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/first[/{}]", true)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/first[/{}]")
             .expect("Should parse");
         let expected = vec![
             MatcherToken::Exact("/first".to_string()),
@@ -476,7 +474,7 @@ mod integration_test {
 
     #[test]
     fn optional_path_capture_all() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{*}[/stuff]", true)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{*}[/stuff]")
             .expect("Should parse");
         let expected = vec![
             MatcherToken::Exact("/".to_string()),
@@ -492,48 +490,12 @@ mod integration_test {
 
     #[test]
     fn case_insensitive() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/hello", true)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/hello")
             .expect("Should parse");
         let settings = MatcherSettings {
             case_insensitive: true,
             ..Default::default()
         };
         match_path_impl(&x, settings, "/HeLLo").expect("should match");
-    }
-
-    #[test]
-    fn match_limited_1() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{(cap)}/thing", true)
-            .expect("Should parse");
-        match_path_impl(&x, MatcherSettings::default(), "/cap/thing").expect("should match");
-    }
-
-    #[test]
-    fn match_limited_2() {
-        let x =
-            yew_router_route_parser::parse_str_and_optimize_tokens("/{(other|cap)}/thing", true)
-                .expect("Should parse");
-        match_path_impl(&x, MatcherSettings::default(), "/cap/thing").expect("should match");
-        match_path_impl(&x, MatcherSettings::default(), "/other/thing").expect("should match");
-    }
-
-    #[test]
-    fn match_limited_3() {
-        let x =
-            yew_router_route_parser::parse_str_and_optimize_tokens("/{key(other|cap)}/thing", true)
-                .expect("Should parse");
-        let captures = match_path_impl(&x, MatcherSettings::default(), "/cap/thing")
-            .expect("should match")
-            .1;
-        assert_eq!(captures["key"], "cap".to_string())
-    }
-
-    #[test]
-    fn match_limited_4() {
-        let x =
-            yew_router_route_parser::parse_str_and_optimize_tokens("/{key(other|cap)}/thing", true)
-                .expect("Should parse");
-        match_path_impl(&x, MatcherSettings::default(), "/snails/thing")
-            .expect_err("should not match");
     }
 }

--- a/src/matcher/route_matcher/match_paths.rs
+++ b/src/matcher/route_matcher/match_paths.rs
@@ -81,17 +81,6 @@ fn match_path_impl<'a, 'b: 'a, CAP: CaptureCollection<'b>>(
                 trace!("Matching '{}' against literal: '{}'", i, literal);
                 tag_possibly_case_sensitive(literal.as_str(), !settings.case_insensitive)(i)?.0
             }
-            MatcherToken::Optional(inner_tokens) => {
-                match opt(|i| match_path_impl(&inner_tokens, settings, i))(i) {
-                    Ok((ii, inner_captures)) => {
-                        if let Some(inner_captures) = inner_captures {
-                            captures.extend2(inner_captures);
-                        }
-                        ii
-                    }
-                    _ => i, // Do nothing if this fails
-                }
-            }
             MatcherToken::Capture(capture) => match &capture.capture_variant {
                 CaptureVariant::Unnamed => {
                     capture_unnamed(i, &mut iter, &capture.allowed_captures)?

--- a/src/matcher/route_matcher/match_paths.rs
+++ b/src/matcher/route_matcher/match_paths.rs
@@ -4,7 +4,7 @@ use crate::matcher::Captures;
 use log::{debug, trace};
 use nom::branch::alt;
 use nom::bytes::complete::{is_not, tag};
-use nom::combinator::{map, opt, verify};
+use nom::combinator::{map, verify};
 use nom::error::ErrorKind;
 use nom::sequence::terminated;
 use nom::IResult;
@@ -81,40 +81,40 @@ fn match_path_impl<'a, 'b: 'a, CAP: CaptureCollection<'b>>(
                 trace!("Matching '{}' against literal: '{}'", i, literal);
                 tag_possibly_case_sensitive(literal.as_str(), !settings.case_insensitive)(i)?.0
             }
-            MatcherToken::Capture(capture) => match &capture.capture_variant {
+            MatcherToken::Capture(capture) => match &capture {
                 CaptureVariant::Unnamed => {
-                    capture_unnamed(i, &mut iter, &capture.allowed_captures)?
+                    capture_unnamed(i, &mut iter, &None)?
                 }
                 CaptureVariant::ManyUnnamed => {
-                    capture_many_unnamed(i, &mut iter, &capture.allowed_captures)?
+                    capture_many_unnamed(i, &mut iter, &None)?
                 }
                 CaptureVariant::NumberedUnnamed { sections } => capture_numbered_named::<CAP>(
                     i,
                     &mut iter,
                     None,
                     *sections,
-                    &capture.allowed_captures,
+                    &None,
                 )?,
                 CaptureVariant::Named(name) => capture_named(
                     i,
                     &mut iter,
                     &name,
                     &mut captures,
-                    &capture.allowed_captures,
+                    &None
                 )?,
                 CaptureVariant::ManyNamed(name) => capture_many_named(
                     i,
                     &mut iter,
                     &name,
                     &mut captures,
-                    &capture.allowed_captures,
+                    &None
                 )?,
                 CaptureVariant::NumberedNamed { sections, name } => capture_numbered_named(
                     i,
                     &mut iter,
                     Some((&name, &mut captures)),
                     *sections,
-                    &capture.allowed_captures,
+                    &None
                 )?,
             },
         };
@@ -130,6 +130,8 @@ fn match_path_impl<'a, 'b: 'a, CAP: CaptureCollection<'b>>(
 ///
 /// It will capture characters until a separator or other invalid character is encountered
 /// and the next string of characters is confirmed to be the next literal.
+///
+// TODO remove the allowed captures parameter, because it is always NONE
 pub fn capture_unnamed<'a>(
     i: &'a str,
     iter: &mut Peekable<Iter<MatcherToken>>,
@@ -155,6 +157,7 @@ pub fn capture_unnamed<'a>(
     Ok(ii)
 }
 
+// TODO remove the allowed captures parameter, because it is always NONE
 fn capture_many_unnamed<'a>(
     i: &'a str,
     iter: &mut Peekable<Iter<MatcherToken>>,
@@ -180,6 +183,7 @@ fn capture_many_unnamed<'a>(
     Ok(ii)
 }
 
+// TODO remove the allowed captures parameter, because it is always NONE
 fn capture_named<'a, 'b: 'a, CAP: CaptureCollection<'b>>(
     i: &'a str,
     iter: &mut Peekable<Iter<MatcherToken>>,
@@ -206,6 +210,7 @@ fn capture_named<'a, 'b: 'a, CAP: CaptureCollection<'b>>(
     }
 }
 
+// TODO remove the allowed captures parameter, because it is always NONE
 fn capture_many_named<'a, 'b, CAP: CaptureCollection<'b>>(
     i: &'a str,
     iter: &mut Peekable<Iter<MatcherToken>>,
@@ -235,6 +240,7 @@ fn capture_many_named<'a, 'b, CAP: CaptureCollection<'b>>(
     }
 }
 
+// TODO remove the allowed captures parameter, because it is always NONE
 fn capture_numbered_named<'a, 'b, CAP: CaptureCollection<'b>>(
     mut i: &'a str,
     iter: &mut Peekable<Iter<MatcherToken>>,
@@ -538,7 +544,7 @@ mod integration_test {
             MatcherToken::Exact("/first".to_string()),
             MatcherToken::Optional(vec![
                 MatcherToken::Exact("/".to_string()),
-                MatcherToken::Capture(Capture::from(CaptureVariant::Unnamed)),
+                MatcherToken::Capture(CaptureVariant::Unnamed),
             ]),
             MatcherToken::Optional(vec![MatcherToken::Exact("/".to_string())]),
         ];
@@ -553,7 +559,7 @@ mod integration_test {
             .expect("Should parse");
         let expected = vec![
             MatcherToken::Exact("/".to_string()),
-            MatcherToken::Capture(Capture::from(CaptureVariant::ManyUnnamed)),
+            MatcherToken::Capture(CaptureVariant::ManyUnnamed),
             MatcherToken::Optional(vec![MatcherToken::Exact("/stuff".to_string())]),
             MatcherToken::Optional(vec![MatcherToken::Exact("/".to_string())]),
         ];

--- a/src/matcher/route_matcher/match_paths.rs
+++ b/src/matcher/route_matcher/match_paths.rs
@@ -314,20 +314,6 @@ mod integration_test {
         assert_eq!(matches["ipsum"], "ipsum".to_string())
     }
 
-    #[test]
-    fn match_n_paths_1() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{*}" )
-            .expect("Should parse");
-        match_path_impl::<Captures>(&x, MatcherSettings::default(), "/anything").expect("should match");
-    }
-
-    #[test]
-    fn match_n_paths_2() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{*}")
-            .expect("Should parse");
-        match_path_impl::<Captures>(&x, MatcherSettings::default(), "/anything/other/thing")
-            .expect("should match");
-    }
 
     #[test]
     fn match_n_paths_3() {
@@ -398,30 +384,6 @@ mod integration_test {
         .expect("Should parse");
         match_path_impl::<Captures>(&x, MatcherSettings::default(), "/a/path?query=thing#test")
             .expect("should match");
-    }
-
-    #[test]
-    fn match_fragment_optional() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("[#test]")
-            .expect("Should parse");
-        match_path_impl::<Captures>(&x, MatcherSettings::default(), "#test").expect("should match");
-        match_path_impl::<Captures>(&x, MatcherSettings::default(), "").expect("should match");
-    }
-    #[test]
-    fn match_fragment_pound_optional() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("#[test]")
-            .expect("Should parse");
-        match_path_impl::<Captures>(&x, MatcherSettings::default(), "#test").expect("should match");
-        match_path_impl::<Captures>(&x, MatcherSettings::default(), "#").expect("should match");
-    }
-
-    #[test]
-    fn match_fragment_optional_with_inner_optional_item() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("[#[test]]")
-            .expect("Should parse");
-        match_path_impl::<Captures>(&x, MatcherSettings::default(), "#test").expect("should match");
-        match_path_impl::<Captures>(&x, MatcherSettings::default(), "").expect("should match");
-        match_path_impl::<Captures>(&x, MatcherSettings::default(), "#").expect("should match");
     }
 
     #[test]

--- a/src/matcher/route_matcher/match_paths.rs
+++ b/src/matcher/route_matcher/match_paths.rs
@@ -263,20 +263,21 @@ where
 //    is_not(INVALID_CHARACTERS)(i)
 //}
 
-//#[cfg(test)]
-#[cfg(feature = "disabled")]
+#[cfg(test)]
 mod integration_test {
     use super::*;
 
     use yew_router_route_parser;
     use yew_router_route_parser::Capture;
+
+    use super::super::Captures;
     //    use nom::combinator::all_consuming;
 
     #[test]
     fn match_query_after_path() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens("/a/path?lorem=ipsum")
             .expect("Should parse");
-        match_path_impl(&x, MatcherSettings::default(), "/a/path?lorem=ipsum")
+        match_path_impl::<Captures>(&x, MatcherSettings::default(), "/a/path?lorem=ipsum")
             .expect("should match");
     }
 
@@ -285,7 +286,7 @@ mod integration_test {
         let x =
             yew_router_route_parser::parse_str_and_optimize_tokens("/a/path/?lorem=ipsum")
                 .expect("Should parse");
-        match_path_impl(&x, MatcherSettings::default(), "/a/path/?lorem=ipsum")
+        match_path_impl::<Captures>(&x, MatcherSettings::default(), "/a/path/?lorem=ipsum")
             .expect("should match");
     }
 
@@ -301,7 +302,7 @@ mod integration_test {
     fn match_query() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens("?lorem=ipsum")
             .expect("Should parse");
-        match_path_impl(&x, MatcherSettings::default(), "?lorem=ipsum").expect("should match");
+        match_path_impl::<Captures>(&x, MatcherSettings::default(), "?lorem=ipsum").expect("should match");
     }
 
     #[test]
@@ -309,7 +310,7 @@ mod integration_test {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens("?lorem={ipsum}")
             .expect("Should parse");
         let (_, matches) =
-            match_path_impl(&x, MatcherSettings::default(), "?lorem=ipsum").expect("should match");
+            match_path_impl::<Captures>(&x, MatcherSettings::default(), "?lorem=ipsum").expect("should match");
         assert_eq!(matches["ipsum"], "ipsum".to_string())
     }
 
@@ -317,14 +318,14 @@ mod integration_test {
     fn match_n_paths_1() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{*}" )
             .expect("Should parse");
-        match_path_impl(&x, MatcherSettings::default(), "/anything").expect("should match");
+        match_path_impl::<Captures>(&x, MatcherSettings::default(), "/anything").expect("should match");
     }
 
     #[test]
     fn match_n_paths_2() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{*}")
             .expect("Should parse");
-        match_path_impl(&x, MatcherSettings::default(), "/anything/other/thing")
+        match_path_impl::<Captures>(&x, MatcherSettings::default(), "/anything/other/thing")
             .expect("should match");
     }
 
@@ -332,7 +333,7 @@ mod integration_test {
     fn match_n_paths_3() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{*:cap}/thing")
             .expect("Should parse");
-        let matches = match_path_impl(&x, MatcherSettings::default(), "/anything/other/thing")
+        let matches: Captures = match_path_impl(&x, MatcherSettings::default(), "/anything/other/thing")
             .expect("should match")
             .1;
         assert_eq!(matches["cap"], "anything/other".to_string())
@@ -342,7 +343,7 @@ mod integration_test {
     fn match_n_paths_4() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{*:cap}/thing")
             .expect("Should parse");
-        let matches = match_path_impl(&x, MatcherSettings::default(), "/anything/thing/thing")
+        let matches: Captures = match_path_impl(&x, MatcherSettings::default(), "/anything/thing/thing")
             .expect("should match")
             .1;
         assert_eq!(matches["cap"], "anything".to_string())
@@ -352,7 +353,7 @@ mod integration_test {
     fn match_path_5() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{cap}/thing")
             .expect("Should parse");
-        let matches = match_path_impl(&x, MatcherSettings::default(), "/anything/thing/thing")
+        let matches: Captures = match_path_impl(&x, MatcherSettings::default(), "/anything/thing/thing")
             .expect("should match")
             .1;
         assert_eq!(matches["cap"], "anything".to_string())
@@ -362,21 +363,21 @@ mod integration_test {
     fn match_fragment() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens("#test")
             .expect("Should parse");
-        match_path_impl(&x, MatcherSettings::default(), "#test").expect("should match");
+        match_path_impl::<Captures>(&x, MatcherSettings::default(), "#test").expect("should match");
     }
 
     #[test]
     fn match_fragment_after_path() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens("/a/path/#test")
             .expect("Should parse");
-        match_path_impl(&x, MatcherSettings::default(), "/a/path/#test").expect("should match");
+        match_path_impl::<Captures>(&x, MatcherSettings::default(), "/a/path/#test").expect("should match");
     }
 
     #[test]
     fn match_fragment_after_path_no_slash() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens("/a/path#test")
             .expect("Should parse");
-        match_path_impl(&x, MatcherSettings::default(), "/a/path#test").expect("should match");
+        match_path_impl::<Captures>(&x, MatcherSettings::default(), "/a/path#test").expect("should match");
     }
 
     #[test]
@@ -385,7 +386,7 @@ mod integration_test {
             "/a/path?query=thing#test",
         )
         .expect("Should parse");
-        match_path_impl(&x, MatcherSettings::default(), "/a/path?query=thing#test")
+        match_path_impl::<Captures>(&x, MatcherSettings::default(), "/a/path?query=thing#test")
             .expect("should match");
     }
 
@@ -395,7 +396,7 @@ mod integration_test {
             "/a/path?query={capture}#test",
         )
         .expect("Should parse");
-        match_path_impl(&x, MatcherSettings::default(), "/a/path?query=thing#test")
+        match_path_impl::<Captures>(&x, MatcherSettings::default(), "/a/path?query=thing#test")
             .expect("should match");
     }
 
@@ -403,88 +404,31 @@ mod integration_test {
     fn match_fragment_optional() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens("[#test]")
             .expect("Should parse");
-        match_path_impl(&x, MatcherSettings::default(), "#test").expect("should match");
-        match_path_impl(&x, MatcherSettings::default(), "").expect("should match");
+        match_path_impl::<Captures>(&x, MatcherSettings::default(), "#test").expect("should match");
+        match_path_impl::<Captures>(&x, MatcherSettings::default(), "").expect("should match");
     }
     #[test]
     fn match_fragment_pound_optional() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens("#[test]")
             .expect("Should parse");
-        match_path_impl(&x, MatcherSettings::default(), "#test").expect("should match");
-        match_path_impl(&x, MatcherSettings::default(), "#").expect("should match");
+        match_path_impl::<Captures>(&x, MatcherSettings::default(), "#test").expect("should match");
+        match_path_impl::<Captures>(&x, MatcherSettings::default(), "#").expect("should match");
     }
 
     #[test]
     fn match_fragment_optional_with_inner_optional_item() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens("[#[test]]")
             .expect("Should parse");
-        match_path_impl(&x, MatcherSettings::default(), "#test").expect("should match");
-        match_path_impl(&x, MatcherSettings::default(), "").expect("should match");
-        match_path_impl(&x, MatcherSettings::default(), "#").expect("should match");
+        match_path_impl::<Captures>(&x, MatcherSettings::default(), "#test").expect("should match");
+        match_path_impl::<Captures>(&x, MatcherSettings::default(), "").expect("should match");
+        match_path_impl::<Captures>(&x, MatcherSettings::default(), "#").expect("should match");
     }
 
     #[test]
     fn capture_as_only_token() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens("{any}")
             .expect("Should parse");
-        match_path_impl(&x, MatcherSettings::default(), "literally_anything")
-            .expect("should match");
-    }
-
-    #[test]
-    fn optional_path_first() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("[/thing]")
-            .expect("Should parse");
-        match_path_impl(&x, MatcherSettings::default(), "").expect("should match");
-        match_path_impl(&x, MatcherSettings::default(), "/thing").expect("should match");
-    }
-
-    #[test]
-    fn optional_path_after_item() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/first[/second]")
-            .expect("Should parse");
-        assert_eq!(
-            x,
-            vec![
-                MatcherToken::Exact("/first".to_string()),
-                MatcherToken::Optional(vec![MatcherToken::Exact("/second".to_string())]),
-                MatcherToken::Optional(vec![MatcherToken::Exact("/".to_string())])
-            ]
-        );
-        match_path_impl(&x, MatcherSettings::default(), "/first").expect("should match");
-        match_path_impl(&x, MatcherSettings::default(), "/first/second").expect("should match");
-    }
-
-    #[test]
-    fn optional_path_any() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/first[/{}]")
-            .expect("Should parse");
-        let expected = vec![
-            MatcherToken::Exact("/first".to_string()),
-            MatcherToken::Optional(vec![
-                MatcherToken::Exact("/".to_string()),
-                MatcherToken::Capture(CaptureVariant::Unnamed),
-            ]),
-            MatcherToken::Optional(vec![MatcherToken::Exact("/".to_string())]),
-        ];
-        assert_eq!(x, expected);
-        match_path_impl(&x, MatcherSettings::default(), "/first").expect("should match");
-        match_path_impl(&x, MatcherSettings::default(), "/first/second").expect("should match");
-    }
-
-    #[test]
-    fn optional_path_capture_all() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("/{*}[/stuff]")
-            .expect("Should parse");
-        let expected = vec![
-            MatcherToken::Exact("/".to_string()),
-            MatcherToken::Capture(CaptureVariant::ManyUnnamed),
-            MatcherToken::Optional(vec![MatcherToken::Exact("/stuff".to_string())]),
-            MatcherToken::Optional(vec![MatcherToken::Exact("/".to_string())]),
-        ];
-        assert_eq!(x, expected);
-        match_path_impl(&x, MatcherSettings::default(), "/some/garbage").expect("should match");
-        match_path_impl(&x, MatcherSettings::default(), "/some/garbage/stuff")
+        match_path_impl::<Captures>(&x, MatcherSettings::default(), "literally_anything")
             .expect("should match");
     }
 
@@ -496,6 +440,6 @@ mod integration_test {
             case_insensitive: true,
             ..Default::default()
         };
-        match_path_impl(&x, settings, "/HeLLo").expect("should match");
+        match_path_impl::<Captures>(&x, settings, "/HeLLo").expect("should match");
     }
 }

--- a/src/matcher/route_matcher/match_paths.rs
+++ b/src/matcher/route_matcher/match_paths.rs
@@ -81,26 +81,18 @@ fn match_path_impl<'a, 'b: 'a, CAP: CaptureCollection<'b>>(
                 tag_possibly_case_sensitive(literal.as_str(), !settings.case_insensitive)(i)?.0
             }
             MatcherToken::Capture(capture) => match &capture {
-                CaptureVariant::Named(name) => capture_named(
-                    i,
-                    &mut iter,
-                    &name,
-                    &mut captures,
-                    &None
-                )?,
-                CaptureVariant::ManyNamed(name) => capture_many_named(
-                    i,
-                    &mut iter,
-                    &name,
-                    &mut captures,
-                    &None
-                )?,
+                CaptureVariant::Named(name) => {
+                    capture_named(i, &mut iter, &name, &mut captures, &None)?
+                }
+                CaptureVariant::ManyNamed(name) => {
+                    capture_many_named(i, &mut iter, &name, &mut captures, &None)?
+                }
                 CaptureVariant::NumberedNamed { sections, name } => capture_numbered_named(
                     i,
                     &mut iter,
                     Some((&name, &mut captures)),
                     *sections,
-                    &None
+                    &None,
                 )?,
             },
         };

--- a/src/matcher/route_matcher/match_paths.rs
+++ b/src/matcher/route_matcher/match_paths.rs
@@ -82,19 +82,19 @@ fn match_path_impl<'a, 'b: 'a, CAP: CaptureCollection<'b>>(
                 tag_possibly_case_sensitive(literal.as_str(), !settings.case_insensitive)(i)?.0
             }
             MatcherToken::Capture(capture) => match &capture {
-                CaptureVariant::Unnamed => {
-                    capture_unnamed(i, &mut iter, &None)?
-                }
-                CaptureVariant::ManyUnnamed => {
-                    capture_many_unnamed(i, &mut iter, &None)?
-                }
-                CaptureVariant::NumberedUnnamed { sections } => capture_numbered_named::<CAP>(
-                    i,
-                    &mut iter,
-                    None,
-                    *sections,
-                    &None,
-                )?,
+//                CaptureVariant::Unnamed => {
+//                    capture_unnamed(i, &mut iter, &None)?
+//                }
+//                CaptureVariant::ManyUnnamed => {
+//                    capture_many_unnamed(i, &mut iter, &None)?
+//                }
+//                CaptureVariant::NumberedUnnamed { sections } => capture_numbered_named::<CAP>(
+//                    i,
+//                    &mut iter,
+//                    None,
+//                    *sections,
+//                    &None,
+//                )?,
                 CaptureVariant::Named(name) => capture_named(
                     i,
                     &mut iter,

--- a/src/matcher/route_matcher/mod.rs
+++ b/src/matcher/route_matcher/mod.rs
@@ -93,10 +93,6 @@ impl RouteMatcher {
                 .iter()
                 .fold(HashSet::new(), |mut acc: HashSet<&str>, token| {
                     match token {
-                        MatcherToken::Optional(t) => {
-                            let captures = capture_names_impl(&t);
-                            acc.extend(captures)
-                        }
                         MatcherToken::Exact(_) => {}
                         MatcherToken::Capture(capture) => match &capture.capture_variant {
                             CaptureVariant::ManyNamed(name)

--- a/src/matcher/route_matcher/mod.rs
+++ b/src/matcher/route_matcher/mod.rs
@@ -100,9 +100,6 @@ impl RouteMatcher {
                             | CaptureVariant::NumberedNamed { name, .. } => {
                                 acc.insert(&name);
                             }
-//                            CaptureVariant::ManyUnnamed
-//                            | CaptureVariant::Unnamed
-//                            | CaptureVariant::NumberedUnnamed { .. } => {}
                         },
                     }
                     acc
@@ -117,14 +114,6 @@ mod tests {
     use super::*;
     use yew_router_route_parser::parser::RouteParserToken;
     use yew_router_route_parser::Capture;
-
-    //    use std::sync::{Once, ONCE_INIT};
-    //    static INIT: Once = ONCE_INIT;
-    //    fn setup_logs() {
-    //        INIT.call_once(|| {
-    //            env_logger::init();
-    //        });
-    //    }
 
     impl From<Vec<RouteParserToken>> for RouteMatcher {
         fn from(tokens: Vec<RouteParserToken>) -> Self {
@@ -192,7 +181,7 @@ mod tests {
             RouteParserToken::Separator,
             RouteParserToken::Exact("a".to_string()),
             RouteParserToken::Separator,
-            RouteParserToken::Capture(Capture::from(CaptureVariant::Unnamed)),
+            RouteParserToken::Capture(Capture::from(CaptureVariant::Named("lorem".to_string()))),
         ];
         let path_matcher = RouteMatcher::from(tokens);
         let (_, _matches) = path_matcher
@@ -204,8 +193,9 @@ mod tests {
     fn match_n() {
         let tokens = vec![
             RouteParserToken::Separator,
-            RouteParserToken::Capture(Capture::from(CaptureVariant::NumberedUnnamed {
+            RouteParserToken::Capture(Capture::from(CaptureVariant::NumberedNamed {
                 sections: 3,
+                name: "lorem".to_string()
             })),
             RouteParserToken::Separator,
             RouteParserToken::Exact("a".to_string()),
@@ -220,8 +210,9 @@ mod tests {
     fn match_n_no_overrun() {
         let tokens = vec![
             RouteParserToken::Separator,
-            RouteParserToken::Capture(Capture::from(CaptureVariant::NumberedUnnamed {
+            RouteParserToken::Capture(Capture::from(CaptureVariant::NumberedNamed {
                 sections: 3,
+                name: "lorem".to_string()
             })),
         ];
         let path_matcher = RouteMatcher::from(tokens);

--- a/src/matcher/route_matcher/mod.rs
+++ b/src/matcher/route_matcher/mod.rs
@@ -186,6 +186,7 @@ mod tests {
             .expect("should parse");
     }
 
+    // TODO fix this test
     #[test]
     fn match_n() {
         let tokens = vec![
@@ -244,7 +245,7 @@ mod tests {
     fn match_many() {
         let tokens = vec![
             RouteParserToken::Separator,
-            RouteParserToken::Capture(Capture::from(CaptureVariant::ManyUnnamed)),
+            RouteParserToken::Capture(Capture::from(CaptureVariant::ManyNamed("lorem".to_string()))),
             RouteParserToken::Separator,
             RouteParserToken::Exact("a".to_string()),
         ];

--- a/src/matcher/route_matcher/mod.rs
+++ b/src/matcher/route_matcher/mod.rs
@@ -192,7 +192,7 @@ mod tests {
             RouteParserToken::Separator,
             RouteParserToken::Capture(Capture::from(CaptureVariant::NumberedNamed {
                 sections: 3,
-                name: "lorem".to_string()
+                name: "lorem".to_string(),
             })),
             RouteParserToken::Separator,
             RouteParserToken::Exact("a".to_string()),
@@ -209,7 +209,7 @@ mod tests {
             RouteParserToken::Separator,
             RouteParserToken::Capture(Capture::from(CaptureVariant::NumberedNamed {
                 sections: 3,
-                name: "lorem".to_string()
+                name: "lorem".to_string(),
             })),
         ];
         let path_matcher = RouteMatcher::from(tokens);

--- a/src/matcher/route_matcher/mod.rs
+++ b/src/matcher/route_matcher/mod.rs
@@ -94,7 +94,7 @@ impl RouteMatcher {
                 .fold(HashSet::new(), |mut acc: HashSet<&str>, token| {
                     match token {
                         MatcherToken::Exact(_) => {}
-                        MatcherToken::Capture(capture) => match &capture.capture_variant {
+                        MatcherToken::Capture(capture) => match &capture {
                             CaptureVariant::ManyNamed(name)
                             | CaptureVariant::Named(name)
                             | CaptureVariant::NumberedNamed { name, .. } => {

--- a/src/matcher/route_matcher/mod.rs
+++ b/src/matcher/route_matcher/mod.rs
@@ -27,8 +27,6 @@ pub struct RouteMatcher {
 /// Settings used for the matcher (and optimization of the parsed tokens that make up the matcher).
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct MatcherSettings {
-    /// Disallow insertion of Optional `/` at the end of paths.
-    pub strict: bool,
     /// A matcher must consume all of the input to succeed.
     pub complete: bool,
     /// All literal matches do not care about case.
@@ -38,7 +36,6 @@ pub struct MatcherSettings {
 impl Default for MatcherSettings {
     fn default() -> Self {
         MatcherSettings {
-            strict: false,
             complete: true,
             case_insensitive: false,
         }
@@ -56,7 +53,7 @@ impl RouteMatcher {
     pub fn new(i: &str, settings: MatcherSettings) -> Result<Self, YewRouterParseError> {
         let tokens = parser::parse(i)?;
         Ok(RouteMatcher {
-            tokens: optimize_tokens(tokens, !settings.strict),
+            tokens: optimize_tokens(tokens),
             settings,
         })
     }
@@ -119,7 +116,7 @@ mod tests {
         fn from(tokens: Vec<RouteParserToken>) -> Self {
             let settings = MatcherSettings::default();
             RouteMatcher {
-                tokens: optimize_tokens(tokens, !settings.strict),
+                tokens: optimize_tokens(tokens),
                 settings,
             }
         }

--- a/src/matcher/route_matcher/mod.rs
+++ b/src/matcher/route_matcher/mod.rs
@@ -173,7 +173,21 @@ mod tests {
     }
 
     #[test]
-    fn match_with_trailing_match_any() {
+    fn match_with_trailing_match_many() {
+        let tokens = vec![
+            RouteParserToken::Separator,
+            RouteParserToken::Exact("a".to_string()),
+            RouteParserToken::Separator,
+            RouteParserToken::Capture(Capture::from(CaptureVariant::ManyNamed("lorem".to_string()))),
+        ];
+        let path_matcher = RouteMatcher::from(tokens);
+        let (_, _matches) = path_matcher
+            .capture_route_into_map("/a/")
+            .expect("should parse");
+    }
+
+    #[test]
+    fn fail_match_with_trailing_match_single() {
         let tokens = vec![
             RouteParserToken::Separator,
             RouteParserToken::Exact("a".to_string()),
@@ -181,10 +195,11 @@ mod tests {
             RouteParserToken::Capture(Capture::from(CaptureVariant::Named("lorem".to_string()))),
         ];
         let path_matcher = RouteMatcher::from(tokens);
-        let (_, _matches) = path_matcher
+        path_matcher
             .capture_route_into_map("/a/")
-            .expect("should parse");
+            .expect_err("should not parse");
     }
+
 
     // TODO fix this test
     #[test]

--- a/src/matcher/route_matcher/mod.rs
+++ b/src/matcher/route_matcher/mod.rs
@@ -100,9 +100,9 @@ impl RouteMatcher {
                             | CaptureVariant::NumberedNamed { name, .. } => {
                                 acc.insert(&name);
                             }
-                            CaptureVariant::ManyUnnamed
-                            | CaptureVariant::Unnamed
-                            | CaptureVariant::NumberedUnnamed { .. } => {}
+//                            CaptureVariant::ManyUnnamed
+//                            | CaptureVariant::Unnamed
+//                            | CaptureVariant::NumberedUnnamed { .. } => {}
                         },
                     }
                     acc

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -61,7 +61,6 @@ pub fn build_route_from_switch<T: Switch, U>(switch: T) -> Route<U> {
     Route { route: buf, state }
 }
 
-
 /// Wrapper that requires that an implementor of Switch must start with a `/`.
 ///
 /// This is needed for any non-derived type provided by yew-router to be used by itself.
@@ -70,12 +69,12 @@ pub fn build_route_from_switch<T: Switch, U>(switch: T) -> Route<U> {
 /// with the `rest` attribute, without a specified leading `/`, this wrapper is needed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct LeadingSlash<T>(pub T);
-impl <U: Switch> Switch for LeadingSlash<U> {
+impl<U: Switch> Switch for LeadingSlash<U> {
     fn from_route_part<T: RouteState>(part: Route<T>) -> (Option<Self>, Option<T>) {
         if part.route.starts_with('/') {
             let route = Route {
                 route: part.route[1..].to_string(),
-                state: part.state
+                state: part.state,
             };
             let (inner, state) = U::from_route_part(route);
             (inner.map(LeadingSlash), state)


### PR DESCRIPTION
Removes support for optionals, limited capture sections, and unnamed capture sections in the MatcherToken structure. Matcher strings that use the old unsupported constructs may panic when converting to the MatcherToken representation.

This PR addresses the first phase described here: https://github.com/yewstack/yew_router/issues/94