### PR TITLE
Add escape support for \ ! {}

### DIFF
--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -117,7 +117,7 @@ fn write_for_token(token: &ShadowMatcherToken, naming_scheme: FieldType) -> Toke
     match token {
         ShadowMatcherToken::Exact(lit) => {
             quote! {
-                write!(buf, #lit).unwrap();
+                write!(buf, "{}", #lit).unwrap();
             }
         }
         ShadowMatcherToken::Capture(capture) => match naming_scheme {

--- a/crates/yew_router_route_parser/src/core.rs
+++ b/crates/yew_router_route_parser/src/core.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use nom::{
     branch::alt,
-    bytes::complete::take_till1,
+    bytes::complete::{tag, take_till1},
     character::{
         complete::{char, digit1},
         is_digit,
@@ -15,8 +15,6 @@ use nom::{
     sequence::{delimited, separated_pair},
     IResult,
 };
-use nom::bytes::complete::escaped;
-use nom::character::complete::one_of;
 
 /// Indicates if the parser is working to create a matcher for a datastructure with named or unnamed fields.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Ord, PartialOrd)]
@@ -114,26 +112,35 @@ fn rust_ident(i: &str) -> IResult<&str, &str, ParseError> {
     })(i)
 }
 
+
+/// Matches escaped items
+fn escaped_item_impl(i: &str) -> IResult<&str, &str> {
+    map(alt((tag("!!"), tag("{{"), tag("}}"))), |s| match s {
+        "!!" => "!",
+        "}}" => "}",
+        "{{" => "{",
+        _ => unreachable!(),
+    })(i)
+}
+
 fn exact_impl(i: &str) -> IResult<&str, &str, ParseError> {
-    let special_chars = r##"/?&#={}!\"##;
-    let escaped_chars = r##"{}!\"##;
-    escaped(
-    take_till1(move |c| special_chars.contains(c)),
-    '\\',
-    one_of(escaped_chars)
-    )(i)
-        .map_err(|x: nom::Err<(&str, ErrorKind)>| {
-            let s = match x {
-                nom::Err::Error((s, _)) => s,
-                nom::Err::Failure((s, _)) => s,
-                nom::Err::Incomplete(_) => panic!(),
-            };
-            nom::Err::Error(ParseError {
-                reason: Some(ParserErrorReason::BadLiteral),
-                expected: vec![ExpectedToken::Literal],
-                offset: 1 + i.len() - s.len(),
-            })
+    let special_chars = r##"/?&#={}!"##;
+    alt((
+        take_till1(move |c| special_chars.contains(c)),
+        escaped_item_impl,
+    ))(i)
+    .map_err(|x: nom::Err<(&str, ErrorKind)>| {
+        let s = match x {
+            nom::Err::Error((s, _))
+            | nom::Err::Failure((s, _)) => s,
+            nom::Err::Incomplete(_) => panic!(),
+        };
+        nom::Err::Error(ParseError {
+            reason: Some(ParserErrorReason::BadLiteral),
+            expected: vec![ExpectedToken::Literal],
+            offset: 1 + i.len() - s.len(),
         })
+    })
 }
 
 pub fn exact(i: &str) -> IResult<&str, RouteParserToken, ParseError> {
@@ -170,6 +177,8 @@ fn capture_single_impl<'a>(
 }
 
 /// Captures {ident}, {*:ident}, {<number>:ident}
+///
+/// Depending on the provided field type, it may also match {}, {*}, and {<number>} for unnamed fields.
 fn capture_impl<'a>(
     field_type: FieldType,
 ) -> impl Fn(&'a str) -> IResult<&'a str, RefCaptureVariant, ParseError> {
@@ -270,6 +279,13 @@ pub fn query<'a>(
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn lit() {
+        let x = exact_impl("hello").expect("Should parse");
+        assert_eq!(x.1, "hello")
+    }
+
 
     #[test]
     fn cap_or_exact_match_lit() {

--- a/crates/yew_router_route_parser/src/optimizer.rs
+++ b/crates/yew_router_route_parser/src/optimizer.rs
@@ -65,17 +65,16 @@ pub fn convert_tokens(tokens: &[RouteParserToken]) -> Vec<MatcherToken> {
     let mut run: Vec<RouteParserToken> = vec![];
 
     fn empty_run(run: &mut Vec<RouteParserToken>) -> MatcherToken {
-        let segment = run
-            .iter()
-            .map(RouteParserToken::as_str)
-            .collect::<String>();
+        let segment = run.iter().map(RouteParserToken::as_str).collect::<String>();
         run.clear();
 
-        let segment = remove_escape_chars(segment);
         MatcherToken::Exact(segment)
     }
 
-    fn empty_run_with_query_cap_at_end(run: &mut Vec<RouteParserToken>, query_lhs: &str) -> MatcherToken {
+    fn empty_run_with_query_cap_at_end(
+        run: &mut Vec<RouteParserToken>,
+        query_lhs: &str,
+    ) -> MatcherToken {
         let segment = run
             .iter()
             .map(RouteParserToken::as_str)
@@ -84,16 +83,7 @@ pub fn convert_tokens(tokens: &[RouteParserToken]) -> Vec<MatcherToken> {
             .collect::<String>();
         run.clear();
 
-        let segment = remove_escape_chars(segment);
         MatcherToken::Exact(segment)
-    }
-
-    fn remove_escape_chars(input: String) -> String {
-        input
-        .replace(r#"\\"#, r#"\"#)
-            .replace(r#"\!"#, r#"!"#)
-            .replace(r#"\{"#, r#"\{"#)
-            .replace(r#"\}"#, r#"\}"#)
     }
 
 

--- a/tests/macro_test/src/lib.rs
+++ b/tests/macro_test/src/lib.rs
@@ -386,4 +386,36 @@ mod tests {
             Test::Variant("lorem".to_string(), "dolor".to_string())
         )
     }
+
+    #[test]
+    fn escape_exclaim() {
+        #[derive(Debug, Switch, PartialEq)]
+        pub enum Test {
+            #[to = "/escape\\!"]
+            Variant,
+        }
+        let route = Route::from("/escape!");
+        let switched = Test::switch(route).expect("should produce item");
+        assert_eq!(
+            switched,
+            Test::Variant
+        )
+    }
+
+    // TODO, apparently the attribute expects a format string, requiring {{ to escape.
+    // Maybe the escapes should operate on a !! \\, {{, }} basis instead of a \*.
+//    #[test]
+//    fn escape_bracket() {
+//        #[derive(Debug, Switch, PartialEq)]
+//        pub enum Test {
+//            #[to = r##"/escape\{"##]
+//            Variant,
+//        }
+//        let route = Route::from("/escape{");
+//        let switched = Test::switch(route).expect("should produce item");
+//        assert_eq!(
+//            switched,
+//            Test::Variant
+//        )
+//    }
 }

--- a/tests/macro_test/src/lib.rs
+++ b/tests/macro_test/src/lib.rs
@@ -391,7 +391,7 @@ mod tests {
     fn escape_exclaim() {
         #[derive(Debug, Switch, PartialEq)]
         pub enum Test {
-            #[to = "/escape\\!"]
+            #[to = "/escape!!"]
             Variant,
         }
         let route = Route::from("/escape!");

--- a/tests/macro_test/src/lib.rs
+++ b/tests/macro_test/src/lib.rs
@@ -402,20 +402,20 @@ mod tests {
         )
     }
 
-    // TODO, apparently the attribute expects a format string, requiring {{ to escape.
-    // Maybe the escapes should operate on a !! \\, {{, }} basis instead of a \*.
-//    #[test]
-//    fn escape_bracket() {
-//        #[derive(Debug, Switch, PartialEq)]
-//        pub enum Test {
-//            #[to = r##"/escape\{"##]
-//            Variant,
-//        }
-//        let route = Route::from("/escape{");
-//        let switched = Test::switch(route).expect("should produce item");
-//        assert_eq!(
-//            switched,
-//            Test::Variant
-//        )
-//    }
+    // TODO, the way that the write to buffer function works, the use of write!() uses the {} literals to break stuff.
+    // Rewrite that to not use write!
+    #[test]
+    fn escape_bracket() {
+        #[derive(Debug, Switch, PartialEq)]
+        pub enum Test {
+            #[to = "/escape{{}}a"]
+            Variant,
+        }
+        let route = Route::from("/escape{}a");
+        let switched = Test::switch(route).expect("should produce item");
+        assert_eq!(
+            switched,
+            Test::Variant
+        )
+    }
 }


### PR DESCRIPTION
Closes https://github.com/yewstack/yew_router/issues/147

This implementation is a little bugged, in that for some reason, the attribute string expects a `{{` to escape to `{` because it thinks its a format string. I figure something is happening out of sight to cause this.

Instead, I think it makes sense to switch to `{{` `}}` `!!` based escaping.