### PR TITLE
Unit Capture Errors

### DIFF
--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -14,6 +14,7 @@ mod shadow;
 mod struct_impl;
 
 use self::attribute::AttrToken;
+use yew_router_route_parser::FieldNamingScheme;
 
 /// Holds data that is required to derive Switch for a struct or a single enum variant.
 pub struct SwitchItem {
@@ -29,14 +30,15 @@ pub fn switch_impl(input: TokenStream) -> TokenStream {
 
     match input.data {
         Data::Struct(ds) => {
-            let field_type = match ds.fields {
-                Fields::Unnamed(_) | Fields::Unit => yew_router_route_parser::FieldType::Unnamed,
-                Fields::Named(_) => yew_router_route_parser::FieldType::Named,
+            let field_naming_scheme = match ds.fields {
+                Fields::Unnamed(_) => FieldNamingScheme::Unnamed,
+                Fields::Unit => FieldNamingScheme::Unit,
+                Fields::Named(_) => FieldNamingScheme::Named,
             };
             let matcher = AttrToken::convert_attributes_to_tokens(input.attrs)
                 .into_iter()
                 .enumerate()
-                .map(|(index, at)| at.into_shadow_matcher_tokens(index, field_type))
+                .map(|(index, at)| at.into_shadow_matcher_tokens(index, field_naming_scheme))
                 .flatten()
                 .collect::<Vec<_>>();
             let switch_item = SwitchItem {
@@ -52,10 +54,11 @@ pub fn switch_impl(input: TokenStream) -> TokenStream {
                 .into_iter()
                 .map(|variant: Variant| {
                     let field_type = match variant.fields {
-                        Fields::Unnamed(_) | Fields::Unit => {
-                            yew_router_route_parser::FieldType::Unnamed
+                        Fields::Unnamed(_) => {
+                            yew_router_route_parser::FieldNamingScheme::Unnamed
                         }
-                        Fields::Named(_) => yew_router_route_parser::FieldType::Named,
+                        Fields::Unit => FieldNamingScheme::Unit,
+                        Fields::Named(_) => yew_router_route_parser::FieldNamingScheme::Named,
                     };
                     let matcher = AttrToken::convert_attributes_to_tokens(variant.attrs)
                         .into_iter()

--- a/crates/yew_router_macro/src/switch/attribute.rs
+++ b/crates/yew_router_macro/src/switch/attribute.rs
@@ -1,5 +1,6 @@
 use crate::switch::shadow::{ShadowCaptureVariant, ShadowMatcherToken};
 use syn::{Attribute, Lit, Meta, MetaNameValue};
+use yew_router_route_parser::FieldNamingScheme;
 
 pub enum AttrToken {
     To(String),
@@ -56,11 +57,11 @@ impl AttrToken {
     pub fn into_shadow_matcher_tokens(
         self,
         id: usize,
-        field_type: yew_router_route_parser::FieldType,
+        field_naming_scheme: FieldNamingScheme,
     ) -> Vec<ShadowMatcherToken> {
         match self {
             AttrToken::To(matcher_string) => {
-                yew_router_route_parser::parse_str_and_optimize_tokens(&matcher_string, field_type)
+                yew_router_route_parser::parse_str_and_optimize_tokens(&matcher_string, field_naming_scheme)
                     .expect("Invalid Matcher") // This is the point where users should see an error message if their matcher string has some syntax error.
                     .into_iter()
                     .map(crate::switch::shadow::ShadowMatcherToken::from)

--- a/crates/yew_router_route_parser/src/core.rs
+++ b/crates/yew_router_route_parser/src/core.rs
@@ -23,6 +23,8 @@ pub enum FieldType {
     Named,
     /// for Thing(String)
     Unnamed,
+    /// for Thing
+    Unit
 }
 
 pub fn get_slash(i: &str) -> IResult<&str, RouteParserToken, ParseError> {
@@ -173,6 +175,13 @@ fn capture_single_impl<'a>(
             alt((named::single_capture_impl, unnamed::single_capture_impl)),
             get_close_bracket,
         )(i),
+        FieldType::Unit => {
+            Err(nom::Err::Error(ParseError {
+                reason: Some(ParserErrorReason::CapturesInUnit),
+                expected: vec![],
+                offset: 0
+            }))
+        }
     }
 }
 
@@ -201,6 +210,13 @@ fn capture_impl<'a>(
                 unnamed::single_capture_impl,
             ));
             delimited(get_open_bracket, inner, get_close_bracket)(i)
+        }
+        FieldType::Unit => {
+            Err(nom::Err::Error(ParseError {
+                reason: Some(ParserErrorReason::CapturesInUnit),
+                expected: vec![],
+                offset: 0
+            }))
         }
     }
 }

--- a/crates/yew_router_route_parser/src/core.rs
+++ b/crates/yew_router_route_parser/src/core.rs
@@ -18,7 +18,7 @@ use nom::{
 
 /// Indicates if the parser is working to create a matcher for a datastructure with named or unnamed fields.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Ord, PartialOrd)]
-pub enum FieldType {
+pub enum FieldNamingScheme {
     /// For Thing { field: String }
     Named,
     /// for Thing(String)
@@ -150,33 +150,34 @@ pub fn exact(i: &str) -> IResult<&str, RouteParserToken, ParseError> {
 }
 
 pub fn capture<'a>(
-    field_type: FieldType,
+    field_naming_scheme: FieldNamingScheme,
 ) -> impl Fn(&'a str) -> IResult<&'a str, RouteParserToken<'a>, ParseError> {
-    map(capture_impl(field_type), RouteParserToken::Capture)
+    map(capture_impl(field_naming_scheme), RouteParserToken::Capture)
 }
 
 pub fn capture_single<'a>(
-    field_type: FieldType,
+    field_naming_scheme: FieldNamingScheme,
 ) -> impl Fn(&'a str) -> IResult<&'a str, RouteParserToken<'a>, ParseError> {
-    map(capture_single_impl(field_type), RouteParserToken::Capture)
+    map(capture_single_impl(field_naming_scheme), RouteParserToken::Capture)
 }
 
 fn capture_single_impl<'a>(
-    field_type: FieldType,
+    field_naming_scheme: FieldNamingScheme,
 ) -> impl Fn(&'a str) -> IResult<&'a str, RefCaptureVariant<'a>, ParseError> {
-    move |i: &str| match field_type {
-        FieldType::Named => delimited(
+    move |i: &str| match field_naming_scheme {
+        FieldNamingScheme::Named => delimited(
             get_open_bracket,
             named::single_capture_impl,
             get_close_bracket,
         )(i),
-        FieldType::Unnamed => delimited(
+        FieldNamingScheme::Unnamed => delimited(
             get_open_bracket,
             alt((named::single_capture_impl, unnamed::single_capture_impl)),
             get_close_bracket,
         )(i),
-        FieldType::Unit => {
-            Err(nom::Err::Error(ParseError {
+        FieldNamingScheme::Unit => {
+            println!("Unit encountered, erroring in capture single");
+            Err(nom::Err::Failure(ParseError {
                 reason: Some(ParserErrorReason::CapturesInUnit),
                 expected: vec![],
                 offset: 0
@@ -187,12 +188,12 @@ fn capture_single_impl<'a>(
 
 /// Captures {ident}, {*:ident}, {<number>:ident}
 ///
-/// Depending on the provided field type, it may also match {}, {*}, and {<number>} for unnamed fields.
+/// Depending on the provided field naming, it may also match {}, {*}, and {<number>} for unnamed fields, or none at all for units.
 fn capture_impl<'a>(
-    field_type: FieldType,
+    field_naming_scheme: FieldNamingScheme,
 ) -> impl Fn(&'a str) -> IResult<&'a str, RefCaptureVariant, ParseError> {
-    move |i: &str| match field_type {
-        FieldType::Named => {
+    move |i: &str| match field_naming_scheme {
+        FieldNamingScheme::Named => {
             let inner = alt((
                 named::many_capture_impl,
                 named::numbered_capture_impl,
@@ -200,7 +201,7 @@ fn capture_impl<'a>(
             ));
             delimited(get_open_bracket, inner, get_close_bracket)(i)
         }
-        FieldType::Unnamed => {
+        FieldNamingScheme::Unnamed => {
             let inner = alt((
                 named::many_capture_impl,
                 unnamed::many_capture_impl,
@@ -211,7 +212,7 @@ fn capture_impl<'a>(
             ));
             delimited(get_open_bracket, inner, get_close_bracket)(i)
         }
-        FieldType::Unit => {
+        FieldNamingScheme::Unit => {
             Err(nom::Err::Error(ParseError {
                 reason: Some(ParserErrorReason::CapturesInUnit),
                 expected: vec![],
@@ -267,11 +268,11 @@ mod unnamed {
 
 /// Gets a capture or exact, mapping it to the CaptureOrExact enum - to provide a limited subset.
 fn cap_or_exact<'a>(
-    field_type: FieldType,
+    field_naming_scheme: FieldNamingScheme,
 ) -> impl Fn(&'a str) -> IResult<&'a str, CaptureOrExact<'a>, ParseError> {
     move |i: &str| {
         alt((
-            map(capture_single_impl(field_type), CaptureOrExact::Capture),
+            map(capture_single_impl(field_naming_scheme), CaptureOrExact::Capture),
             map(exact_impl, CaptureOrExact::Exact),
         ))(i)
     }
@@ -279,11 +280,11 @@ fn cap_or_exact<'a>(
 
 /// Matches a query
 pub fn query<'a>(
-    field_type: FieldType,
+    field_naming_scheme: FieldNamingScheme,
 ) -> impl Fn(&'a str) -> IResult<&'a str, RouteParserToken<'a>, ParseError> {
     move |i: &str| {
         map(
-            separated_pair(exact_impl, get_eq, cap_or_exact(field_type)),
+            separated_pair(exact_impl, get_eq, cap_or_exact(field_naming_scheme)),
             |(ident, capture_or_exact)| RouteParserToken::Query {
                 ident,
                 capture_or_exact,
@@ -305,29 +306,29 @@ mod test {
 
     #[test]
     fn cap_or_exact_match_lit() {
-        cap_or_exact(FieldType::Named)("lorem").expect("Should parse");
+        cap_or_exact(FieldNamingScheme::Named)("lorem").expect("Should parse");
     }
     #[test]
     fn cap_or_exact_match_cap() {
-        cap_or_exact(FieldType::Named)("{lorem}").expect("Should parse");
+        cap_or_exact(FieldNamingScheme::Named)("{lorem}").expect("Should parse");
     }
 
     #[test]
     fn query_section_exact() {
-        query(FieldType::Named)("lorem=ipsum").expect("should parse");
+        query(FieldNamingScheme::Named)("lorem=ipsum").expect("should parse");
     }
 
     #[test]
     fn query_section_capture_named() {
-        query(FieldType::Named)("lorem={ipsum}").expect("should parse");
+        query(FieldNamingScheme::Named)("lorem={ipsum}").expect("should parse");
     }
     #[test]
     fn query_section_capture_named_fails_without_key() {
-        query(FieldType::Named)("lorem={}").expect_err("should not parse");
+        query(FieldNamingScheme::Named)("lorem={}").expect_err("should not parse");
     }
     #[test]
     fn query_section_capture_unnamed_succeeds_without_key() {
-        query(FieldType::Unnamed)("lorem={}").expect("should parse");
+        query(FieldNamingScheme::Unnamed)("lorem={}").expect("should parse");
     }
 
     #[test]

--- a/crates/yew_router_route_parser/src/error.rs
+++ b/crates/yew_router_route_parser/src/error.rs
@@ -191,6 +191,8 @@ pub enum ParserErrorReason {
     BadLiteral,
     /// Invalid state
     InvalidState,
+    /// Can't have capture sections for unit structs/variants
+    CapturesInUnit,
     /// Internal check on valid state transitions
     /// This should never actually be created.
     NotAllowedStateTransition,
@@ -236,6 +238,9 @@ impl fmt::Display for ParserErrorReason {
             }
             ParserErrorReason::BadLiteral => {
                 f.write_str("Malformed literal.")?;
+            }
+            ParserErrorReason::CapturesInUnit => {
+                f.write_str("Cannot have a capture section for a unit struct or variant.")?;
             }
         }
         Ok(())

--- a/crates/yew_router_route_parser/src/lib.rs
+++ b/crates/yew_router_route_parser/src/lib.rs
@@ -16,7 +16,7 @@
 mod core;
 mod error;
 pub mod parser;
-pub use crate::core::FieldType;
+pub use crate::core::FieldNamingScheme;
 pub use error::{ParseError, PrettyParseError};
 mod optimizer;
 pub use optimizer::{convert_tokens, parse_str_and_optimize_tokens};

--- a/crates/yew_router_route_parser/src/optimizer.rs
+++ b/crates/yew_router_route_parser/src/optimizer.rs
@@ -3,7 +3,7 @@ use crate::{
     parser::{parse, CaptureOrExact, RefCaptureVariant, RouteParserToken},
 };
 
-use crate::{core::FieldType, CaptureVariant, MatcherToken};
+use crate::{core::FieldNamingScheme, CaptureVariant, MatcherToken};
 
 impl<'a> From<RefCaptureVariant<'a>> for CaptureVariant {
     fn from(v: RefCaptureVariant<'a>) -> Self {
@@ -50,9 +50,9 @@ impl<'a> RouteParserToken<'a> {
 /// Parse the provided "matcher string" and then optimize the tokens.
 pub fn parse_str_and_optimize_tokens(
     i: &str,
-    field_type: FieldType,
+    field_naming_scheme: FieldNamingScheme,
 ) -> Result<Vec<MatcherToken>, PrettyParseError> {
-    let tokens = parse(i, field_type)?;
+    let tokens = parse(i, field_naming_scheme)?;
     Ok(convert_tokens(&tokens))
 }
 

--- a/examples/switch/src/main.rs
+++ b/examples/switch/src/main.rs
@@ -1,102 +1,102 @@
 use yew_router::{route::Route, Switch};
 
 fn main() {
-//    let route = Route::<()>::from("/some/route");
-//    let app_route = AppRoute::switch(route);
-//    dbg!(app_route);
-//
-//    let route = Route::<()>::from("/some/thing/other");
-//    let app_route = AppRoute::switch(route);
-//    dbg!(app_route);
-//
-//    let route = Route::<()>::from("/another/other");
-//    let app_route = AppRoute::switch(route);
-//    dbg!(app_route);
-//
-//    let route = Route::<()>::from("/inner/left");
-//    let app_route = AppRoute::switch(route);
-//    dbg!(app_route);
-//
-//    let route = Route::<()>::from("/yeet"); // should not match
-//    let app_route = AppRoute::switch(route);
-//    dbg!(app_route);
-//
-//    let route = Route::<()>::from("/single/32");
-//    let app_route = AppRoute::switch(route);
-//    dbg!(app_route);
-//
-//    let route = Route::<()>::from("/othersingle/472");
-//    let app_route = AppRoute::switch(route);
-//    dbg!(app_route);
-//
-//    let route = Route::<()>::from("/option/test");
-//    let app_route = AppRoute::switch(route);
-//    dbg!(app_route);
-//
-//    let mut buf = String::new();
-//    AppRoute::Another("yeet".to_string()).build_route_section::<()>(&mut buf);
-//    println!("{}", buf);
-//
-//    let mut buf = String::new();
-//    AppRoute::Something {
-//        thing: "yeet".to_string(),
-//        other: "yote".to_string(),
-//    }
-//    .build_route_section::<()>(&mut buf);
-//    println!("{}", buf);
-//
-//    let mut buf = String::new();
-//    OtherSingle(23).build_route_section::<()>(&mut buf);
-//    println!("{}", buf);
+    let route = Route::<()>::from("/some/route");
+    let app_route = AppRoute::switch(route);
+    dbg!(app_route);
+
+    let route = Route::<()>::from("/some/thing/other");
+    let app_route = AppRoute::switch(route);
+    dbg!(app_route);
+
+    let route = Route::<()>::from("/another/other");
+    let app_route = AppRoute::switch(route);
+    dbg!(app_route);
+
+    let route = Route::<()>::from("/inner/left");
+    let app_route = AppRoute::switch(route);
+    dbg!(app_route);
+
+    let route = Route::<()>::from("/yeet"); // should not match
+    let app_route = AppRoute::switch(route);
+    dbg!(app_route);
+
+    let route = Route::<()>::from("/single/32");
+    let app_route = AppRoute::switch(route);
+    dbg!(app_route);
+
+    let route = Route::<()>::from("/othersingle/472");
+    let app_route = AppRoute::switch(route);
+    dbg!(app_route);
+
+    let route = Route::<()>::from("/option/test");
+    let app_route = AppRoute::switch(route);
+    dbg!(app_route);
+
+    let mut buf = String::new();
+    AppRoute::Another("yeet".to_string()).build_route_section::<()>(&mut buf);
+    println!("{}", buf);
+
+    let mut buf = String::new();
+    AppRoute::Something {
+        thing: "yeet".to_string(),
+        other: "yote".to_string(),
+    }
+    .build_route_section::<()>(&mut buf);
+    println!("{}", buf);
+
+    let mut buf = String::new();
+    OtherSingle(23).build_route_section::<()>(&mut buf);
+    println!("{}", buf);
 }
 
-//#[derive(Debug, Switch)]
-//pub enum AppRoute {
-//    #[to = "/some/route"]
-//    SomeRoute,
-//    #[to = "/some/{thing}/{other}"]
-//    // If you have a variant with named fields, the field names should appear in the matcher string.
-//    Something { thing: String, other: String },
-//    #[to = "/another/{}"] // Tuple-enums don't need names in the capture groups.
-//    Another(String),
-//    #[to = "/doot/{}/{something}"]
-//    // You can still puts names in the capture groups to improve readability.
-//    Yeet(String, String),
-//    #[to = "/inner"]
-//    #[rest] // same as /inner{*}
-//    Nested(InnerRoute),
-//    #[rest] // Rest delegates the remaining input to the next attribute
-//    Single(Single),
-//    #[rest]
-//    OtherSingle(OtherSingle),
-//    /// Because this is an option, the inner item doesn't have to match.
-//    #[to = "/option/{}"]
-//    Optional(Option<String>),
-//    /// Because this is an option, a corresponding capture group doesn't need to exist
-//    #[to = "/missing/capture"]
-//    MissingCapture(Option<String>),
-//}
-//
-//#[derive(Switch, Debug)]
-//pub enum InnerRoute {
-//    #[to = "/left"]
-//    Left,
-//    #[to = "/right"]
-//    Right,
-//}
-//
-//#[derive(Switch, Debug)]
-//#[to = "/single/{number}"]
-//pub struct Single {
-//    number: u32,
-//}
-//
-//#[derive(Switch, Debug)]
-//#[to = "/othersingle/{number}"]
-//pub struct OtherSingle(u32);
+#[derive(Debug, Switch)]
+pub enum AppRoute {
+    #[to = "/some/route"]
+    SomeRoute,
+    #[to = "/some/{thing}/{other}"]
+    // If you have a variant with named fields, the field names should appear in the matcher string.
+    Something { thing: String, other: String },
+    #[to = "/another/{}"] // Tuple-enums don't need names in the capture groups.
+    Another(String),
+    #[to = "/doot/{}/{something}"]
+    // You can still puts names in the capture groups to improve readability.
+    Yeet(String, String),
+    #[to = "/inner"]
+    #[rest] // same as /inner{*}
+    Nested(InnerRoute),
+    #[rest] // Rest delegates the remaining input to the next attribute
+    Single(Single),
+    #[rest]
+    OtherSingle(OtherSingle),
+    /// Because this is an option, the inner item doesn't have to match.
+    #[to = "/option/{}"]
+    Optional(Option<String>),
+    /// Because this is an option, a corresponding capture group doesn't need to exist
+    #[to = "/missing/capture"]
+    MissingCapture(Option<String>),
+}
 
 #[derive(Switch, Debug)]
- pub enum Bad {
-    #[to = "/bad_route/{hello}"]
-    X,
+pub enum InnerRoute {
+    #[to = "/left"]
+    Left,
+    #[to = "/right"]
+    Right,
 }
+
+#[derive(Switch, Debug)]
+#[to = "/single/{number}"]
+pub struct Single {
+    number: u32,
+}
+
+#[derive(Switch, Debug)]
+#[to = "/othersingle/{number}"]
+pub struct OtherSingle(u32);
+
+//#[derive(Switch, Debug)]
+// pub enum Bad {
+//    #[to = "/bad_route/{hello}"]
+//    X,
+//}

--- a/examples/switch/src/main.rs
+++ b/examples/switch/src/main.rs
@@ -1,102 +1,102 @@
 use yew_router::{route::Route, Switch};
 
 fn main() {
-    let route = Route::<()>::from("/some/route");
-    let app_route = AppRoute::switch(route);
-    dbg!(app_route);
-
-    let route = Route::<()>::from("/some/thing/other");
-    let app_route = AppRoute::switch(route);
-    dbg!(app_route);
-
-    let route = Route::<()>::from("/another/other");
-    let app_route = AppRoute::switch(route);
-    dbg!(app_route);
-
-    let route = Route::<()>::from("/inner/left");
-    let app_route = AppRoute::switch(route);
-    dbg!(app_route);
-
-    let route = Route::<()>::from("/yeet"); // should not match
-    let app_route = AppRoute::switch(route);
-    dbg!(app_route);
-
-    let route = Route::<()>::from("/single/32");
-    let app_route = AppRoute::switch(route);
-    dbg!(app_route);
-
-    let route = Route::<()>::from("/othersingle/472");
-    let app_route = AppRoute::switch(route);
-    dbg!(app_route);
-
-    let route = Route::<()>::from("/option/test");
-    let app_route = AppRoute::switch(route);
-    dbg!(app_route);
-
-    let mut buf = String::new();
-    AppRoute::Another("yeet".to_string()).build_route_section::<()>(&mut buf);
-    println!("{}", buf);
-
-    let mut buf = String::new();
-    AppRoute::Something {
-        thing: "yeet".to_string(),
-        other: "yote".to_string(),
-    }
-    .build_route_section::<()>(&mut buf);
-    println!("{}", buf);
-
-    let mut buf = String::new();
-    OtherSingle(23).build_route_section::<()>(&mut buf);
-    println!("{}", buf);
+//    let route = Route::<()>::from("/some/route");
+//    let app_route = AppRoute::switch(route);
+//    dbg!(app_route);
+//
+//    let route = Route::<()>::from("/some/thing/other");
+//    let app_route = AppRoute::switch(route);
+//    dbg!(app_route);
+//
+//    let route = Route::<()>::from("/another/other");
+//    let app_route = AppRoute::switch(route);
+//    dbg!(app_route);
+//
+//    let route = Route::<()>::from("/inner/left");
+//    let app_route = AppRoute::switch(route);
+//    dbg!(app_route);
+//
+//    let route = Route::<()>::from("/yeet"); // should not match
+//    let app_route = AppRoute::switch(route);
+//    dbg!(app_route);
+//
+//    let route = Route::<()>::from("/single/32");
+//    let app_route = AppRoute::switch(route);
+//    dbg!(app_route);
+//
+//    let route = Route::<()>::from("/othersingle/472");
+//    let app_route = AppRoute::switch(route);
+//    dbg!(app_route);
+//
+//    let route = Route::<()>::from("/option/test");
+//    let app_route = AppRoute::switch(route);
+//    dbg!(app_route);
+//
+//    let mut buf = String::new();
+//    AppRoute::Another("yeet".to_string()).build_route_section::<()>(&mut buf);
+//    println!("{}", buf);
+//
+//    let mut buf = String::new();
+//    AppRoute::Something {
+//        thing: "yeet".to_string(),
+//        other: "yote".to_string(),
+//    }
+//    .build_route_section::<()>(&mut buf);
+//    println!("{}", buf);
+//
+//    let mut buf = String::new();
+//    OtherSingle(23).build_route_section::<()>(&mut buf);
+//    println!("{}", buf);
 }
 
-#[derive(Debug, Switch)]
-pub enum AppRoute {
-    #[to = "/some/route"]
-    SomeRoute,
-    #[to = "/some/{thing}/{other}"]
-    // If you have a variant with named fields, the field names should appear in the matcher string.
-    Something { thing: String, other: String },
-    #[to = "/another/{}"] // Tuple-enums don't need names in the capture groups.
-    Another(String),
-    #[to = "/doot/{}/{something}"]
-    // You can still puts names in the capture groups to improve readability.
-    Yeet(String, String),
-    #[to = "/inner"]
-    #[rest] // same as /inner{*}
-    Nested(InnerRoute),
-    #[rest] // Rest delegates the remaining input to the next attribute
-    Single(Single),
-    #[rest]
-    OtherSingle(OtherSingle),
-    /// Because this is an option, the inner item doesn't have to match.
-    #[to = "/option/{}"]
-    Optional(Option<String>),
-    /// Because this is an option, a corresponding capture group doesn't need to exist
-    #[to = "/missing/capture"]
-    MissingCapture(Option<String>),
-}
-
-#[derive(Switch, Debug)]
-pub enum InnerRoute {
-    #[to = "/left"]
-    Left,
-    #[to = "/right"]
-    Right,
-}
-
-#[derive(Switch, Debug)]
-#[to = "/single/{number}"]
-pub struct Single {
-    number: u32,
-}
-
-#[derive(Switch, Debug)]
-#[to = "/othersingle/{number}"]
-pub struct OtherSingle(u32);
-
-//#[derive(Switch, Debug)]
-// pub enum Bad {
-//    #[to = "/bad_route{4hello}"]
-//    X,
+//#[derive(Debug, Switch)]
+//pub enum AppRoute {
+//    #[to = "/some/route"]
+//    SomeRoute,
+//    #[to = "/some/{thing}/{other}"]
+//    // If you have a variant with named fields, the field names should appear in the matcher string.
+//    Something { thing: String, other: String },
+//    #[to = "/another/{}"] // Tuple-enums don't need names in the capture groups.
+//    Another(String),
+//    #[to = "/doot/{}/{something}"]
+//    // You can still puts names in the capture groups to improve readability.
+//    Yeet(String, String),
+//    #[to = "/inner"]
+//    #[rest] // same as /inner{*}
+//    Nested(InnerRoute),
+//    #[rest] // Rest delegates the remaining input to the next attribute
+//    Single(Single),
+//    #[rest]
+//    OtherSingle(OtherSingle),
+//    /// Because this is an option, the inner item doesn't have to match.
+//    #[to = "/option/{}"]
+//    Optional(Option<String>),
+//    /// Because this is an option, a corresponding capture group doesn't need to exist
+//    #[to = "/missing/capture"]
+//    MissingCapture(Option<String>),
 //}
+//
+//#[derive(Switch, Debug)]
+//pub enum InnerRoute {
+//    #[to = "/left"]
+//    Left,
+//    #[to = "/right"]
+//    Right,
+//}
+//
+//#[derive(Switch, Debug)]
+//#[to = "/single/{number}"]
+//pub struct Single {
+//    number: u32,
+//}
+//
+//#[derive(Switch, Debug)]
+//#[to = "/othersingle/{number}"]
+//pub struct OtherSingle(u32);
+
+#[derive(Switch, Debug)]
+ pub enum Bad {
+    #[to = "/bad_route/{hello}"]
+    X,
+}

--- a/src/matcher/matcher_impl.rs
+++ b/src/matcher/matcher_impl.rs
@@ -215,7 +215,7 @@ fn valid_many_capture_characters(i: &str) -> IResult<&str, &str> {
 mod integration_test {
     use super::*;
 
-    use yew_router_route_parser::{self, FieldType};
+    use yew_router_route_parser::{self, FieldNamingScheme};
 
     use super::super::Captures;
     //    use nom::combinator::all_consuming;
@@ -224,7 +224,7 @@ mod integration_test {
     fn match_query_after_path() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens(
             "/a/path?lorem=ipsum",
-            FieldType::Unnamed,
+            FieldNamingScheme::Unnamed,
         )
         .expect("Should parse");
         matcher_impl::<Captures>(&x, MatcherSettings::default(), "/a/path?lorem=ipsum")
@@ -235,7 +235,7 @@ mod integration_test {
     fn match_query_after_path_trailing_slash() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens(
             "/a/path/?lorem=ipsum",
-            FieldType::Unnamed,
+            FieldNamingScheme::Unnamed,
         )
         .expect("Should parse");
         matcher_impl::<Captures>(&x, MatcherSettings::default(), "/a/path/?lorem=ipsum")
@@ -246,7 +246,7 @@ mod integration_test {
     fn match_query() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens(
             "?lorem=ipsum",
-            FieldType::Unnamed,
+            FieldNamingScheme::Unnamed,
         )
         .expect("Should parse");
         matcher_impl::<Captures>(&x, MatcherSettings::default(), "?lorem=ipsum")
@@ -257,7 +257,7 @@ mod integration_test {
     fn named_capture_query() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens(
             "?lorem={ipsum}",
-            FieldType::Unnamed,
+            FieldNamingScheme::Unnamed,
         )
         .expect("Should parse");
         let (_, matches) = matcher_impl::<Captures>(&x, MatcherSettings::default(), "?lorem=ipsum")
@@ -269,7 +269,7 @@ mod integration_test {
     fn match_n_paths_3() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens(
             "/{*:cap}/thing",
-            FieldType::Unnamed,
+            FieldNamingScheme::Unnamed,
         )
         .expect("Should parse");
         let matches: Captures =
@@ -283,7 +283,7 @@ mod integration_test {
     fn match_n_paths_4() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens(
             "/{*:cap}/thing",
-            FieldType::Unnamed,
+            FieldNamingScheme::Unnamed,
         )
         .expect("Should parse");
         let matches: Captures =
@@ -297,7 +297,7 @@ mod integration_test {
     fn match_path_5() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens(
             "/{cap}/thing",
-            FieldType::Unnamed,
+            FieldNamingScheme::Unnamed,
         )
         .expect("Should parse");
         let matches: Captures =
@@ -309,7 +309,7 @@ mod integration_test {
 
     #[test]
     fn match_fragment() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("#test", FieldType::Unnamed)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("#test", FieldNamingScheme::Unnamed)
             .expect("Should parse");
         matcher_impl::<Captures>(&x, MatcherSettings::default(), "#test").expect("should match");
     }
@@ -318,7 +318,7 @@ mod integration_test {
     fn match_fragment_after_path() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens(
             "/a/path/#test",
-            FieldType::Unnamed,
+            FieldNamingScheme::Unnamed,
         )
         .expect("Should parse");
         matcher_impl::<Captures>(&x, MatcherSettings::default(), "/a/path/#test")
@@ -329,7 +329,7 @@ mod integration_test {
     fn match_fragment_after_path_no_slash() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens(
             "/a/path#test",
-            FieldType::Unnamed,
+            FieldNamingScheme::Unnamed,
         )
         .expect("Should parse");
         matcher_impl::<Captures>(&x, MatcherSettings::default(), "/a/path#test")
@@ -340,7 +340,7 @@ mod integration_test {
     fn match_fragment_after_query() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens(
             "/a/path?query=thing#test",
-            FieldType::Unnamed,
+            FieldNamingScheme::Unnamed,
         )
         .expect("Should parse");
         matcher_impl::<Captures>(&x, MatcherSettings::default(), "/a/path?query=thing#test")
@@ -351,7 +351,7 @@ mod integration_test {
     fn match_fragment_after_query_capture() {
         let x = yew_router_route_parser::parse_str_and_optimize_tokens(
             "/a/path?query={capture}#test",
-            FieldType::Unnamed,
+            FieldNamingScheme::Unnamed,
         )
         .expect("Should parse");
         matcher_impl::<Captures>(&x, MatcherSettings::default(), "/a/path?query=thing#test")
@@ -360,7 +360,7 @@ mod integration_test {
 
     #[test]
     fn capture_as_only_token() {
-        let x = yew_router_route_parser::parse_str_and_optimize_tokens("{any}", FieldType::Unnamed)
+        let x = yew_router_route_parser::parse_str_and_optimize_tokens("{any}", FieldNamingScheme::Unnamed)
             .expect("Should parse");
         matcher_impl::<Captures>(&x, MatcherSettings::default(), "literally_anything")
             .expect("should match");
@@ -369,7 +369,7 @@ mod integration_test {
     #[test]
     fn case_insensitive() {
         let x =
-            yew_router_route_parser::parse_str_and_optimize_tokens("/hello", FieldType::Unnamed)
+            yew_router_route_parser::parse_str_and_optimize_tokens("/hello", FieldNamingScheme::Unnamed)
                 .expect("Should parse");
         let settings = MatcherSettings {
             case_insensitive: true,
@@ -381,7 +381,7 @@ mod integration_test {
     #[test]
     fn end_token() {
         let x =
-            yew_router_route_parser::parse_str_and_optimize_tokens("/lorem!", FieldType::Unnamed)
+            yew_router_route_parser::parse_str_and_optimize_tokens("/lorem!", FieldNamingScheme::Unnamed)
                 .expect("Should parse");
 
         matcher_impl::<Captures>(&x, Default::default(), "/lorem/ipsum")

--- a/src/matcher/mod.rs
+++ b/src/matcher/mod.rs
@@ -47,7 +47,7 @@ impl RouteMatcher {
     /// Creates a new Matcher with settings.
     pub fn new(i: &str, settings: MatcherSettings) -> Result<Self, PrettyParseError> {
         Ok(RouteMatcher {
-            tokens: parse_str_and_optimize_tokens(i, yew_router_route_parser::FieldType::Unnamed)?, /* TODO this field type should be a superset of Named, but it would be better to source this from settings, and make sure that the macro generates settings as such. */
+            tokens: parse_str_and_optimize_tokens(i, yew_router_route_parser::FieldNamingScheme::Unnamed)?, /* TODO this field type should be a superset of Named, but it would be better to source this from settings, and make sure that the macro generates settings as such. */
             settings,
         })
     }


### PR DESCRIPTION
Closes https://github.com/yewstack/yew_router/issues/161


Produces error messages like this if you have a capture section for a unit struct/tuple.

```
   = help: message: Invalid Matcher: Could not parse route.
           Route: /bad_route/{hello}
           ------------------^
           Expected: <literal>, ?, #, !
           Reason: Cannot have a capture section for a unit struct or variant.
```