### PR TITLE
Redirect in url bar

### DIFF
--- a/crates/yew_router_macro/src/lib.rs
+++ b/crates/yew_router_macro/src/lib.rs
@@ -54,7 +54,7 @@ mod switch;
 /// ```
 /// use yew_router::Switch;
 ///
-/// #[derive(Switch)]
+/// #[derive(Switch, Clone)]
 /// enum AppRoute {
 ///     #[to = "/some/simple/route"]
 ///     SomeSimpleRoute,
@@ -68,7 +68,7 @@ mod switch;
 ///     Inner(InnerRoute),
 /// }
 ///
-/// #[derive(Switch)]
+/// #[derive(Switch, Clone)]
 /// #[to = "/inner/route/{first}/{second}"]
 /// struct InnerRoute {
 ///     first: String,

--- a/examples/minimal/src/main.rs
+++ b/examples/minimal/src/main.rs
@@ -24,7 +24,7 @@ pub enum Msg {
     ChangeRoute(AppRoute),
 }
 
-#[derive(Debug, Switch)]
+#[derive(Debug, Switch, Clone)]
 pub enum AppRoute {
     #[to = "/a/{anything}"]
     A(String),

--- a/examples/router_component/src/b_component.rs
+++ b/examples/router_component/src/b_component.rs
@@ -15,7 +15,7 @@ pub struct Props {
     pub sub_path: Option<String>,
 }
 
-#[derive(Debug, Switch)]
+#[derive(Debug, Switch, Clone)]
 pub enum BRoute {
     #[to = "/{num}?sup_path={sub_path}"]
     Both(usize, String),

--- a/examples/router_component/src/main.rs
+++ b/examples/router_component/src/main.rs
@@ -76,7 +76,7 @@ impl Component for Model {
     }
 }
 
-#[derive(Debug, Switch)]
+#[derive(Debug, Switch, Clone)]
 pub enum AppRoute {
     #[to = "/a{*:inner}"]
     A(AllowMissing<ARoute>),
@@ -90,6 +90,6 @@ pub enum AppRoute {
     PageNotFound(Option<String>),
 }
 
-#[derive(Debug, Switch, PartialEq, Clone)]
+#[derive(Debug, Switch, PartialEq, Clone, Copy)]
 #[to = "/c"]
 pub struct ARoute;

--- a/examples/switch/src/main.rs
+++ b/examples/switch/src/main.rs
@@ -50,7 +50,7 @@ fn main() {
     println!("{}", buf);
 }
 
-#[derive(Debug, Switch)]
+#[derive(Debug, Switch, Clone)]
 pub enum AppRoute {
     #[to = "/some/route"]
     SomeRoute,
@@ -77,7 +77,7 @@ pub enum AppRoute {
     MissingCapture(Option<String>),
 }
 
-#[derive(Switch, Debug)]
+#[derive(Switch, Debug, Clone)]
 pub enum InnerRoute {
     #[to = "/left"]
     Left,
@@ -85,13 +85,13 @@ pub enum InnerRoute {
     Right,
 }
 
-#[derive(Switch, Debug)]
+#[derive(Switch, Debug, Clone)]
 #[to = "/single/{number}"]
 pub struct Single {
     number: u32,
 }
 
-#[derive(Switch, Debug)]
+#[derive(Switch, Debug, Clone)]
 #[to = "/othersingle/{number}"]
 pub struct OtherSingle(u32);
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -62,7 +62,7 @@ impl<'de, T> RouterState<'de> for T where T: AgentState<'de> + PartialEq {}
 /// }
 /// ```
 #[derive(Debug)]
-pub struct Router<T: for<'de> RouterState<'de>, SW: Switch + 'static, M: 'static> {
+pub struct Router<T: for<'de> RouterState<'de>, SW: Switch + Clone + 'static, M: 'static> {
     switch: Option<SW>,
     props: Props<T, SW, M>,
     router_agent: RouteAgentBridge<T>,
@@ -71,7 +71,7 @@ pub struct Router<T: for<'de> RouterState<'de>, SW: Switch + 'static, M: 'static
 impl<T, SW, M> Router<T, SW, M>
 where
     T: for<'de> RouterState<'de>,
-    SW: Switch + 'static,
+    SW: Switch + Clone + 'static,
     M: 'static,
 {
     // TODO render fn name is overloaded now with that of the trait: Renderable<_> this should be changed. Maybe: display, show, switch, inner...

--- a/src/router.rs
+++ b/src/router.rs
@@ -62,7 +62,7 @@ impl<'de, T> RouterState<'de> for T where T: AgentState<'de> + PartialEq {}
 /// }
 /// ```
 #[derive(Debug)]
-pub struct Router<T: for<'de> RouterState<'de>, SW: Switch + Clone + 'static, M: 'static> {
+pub struct Router<T: for<'de> RouterState<'de>, SW: Switch  + Clone + 'static, M: 'static> {
     switch: Option<SW>,
     props: Props<T, SW, M>,
     router_agent: RouteAgentBridge<T>,
@@ -125,16 +125,16 @@ impl<T, M> From<M> for Msg<T, M> {
 pub trait RenderFn<CTX: Component, SW>: Fn(SW) -> Html<CTX> {}
 impl<T, CTX: Component, SW> RenderFn<CTX, SW> for T where T: Fn(SW) -> Html<CTX> {}
 /// Owned Render function.
-pub struct Render<T: for<'de> RouterState<'de>, SW: Switch + 'static, M: 'static>(
+pub struct Render<T: for<'de> RouterState<'de>, SW: Switch + Clone+ 'static, M: 'static>(
     pub(crate) Rc<dyn RenderFn<Router<T, SW, M>, SW>>,
 );
-impl<T: for<'de> RouterState<'de>, SW: Switch, M> Render<T, SW, M> {
+impl<T: for<'de> RouterState<'de>, SW: Switch + Clone, M> Render<T, SW, M> {
     /// New render function
     fn new<F: RenderFn<Router<T, SW, M>, SW> + 'static>(f: F) -> Self {
         Render(Rc::new(f))
     }
 }
-impl<T: for<'de> RouterState<'de>, SW: Switch, M> Debug for Render<T, SW, M> {
+impl<T: for<'de> RouterState<'de>, SW: Switch + Clone, M> Debug for Render<T, SW, M> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("Render").finish()
     }
@@ -163,7 +163,7 @@ impl<STATE: for<'de> RouterState<'de>, SW: Switch, M> Debug for Redirect<SW, STA
 
 /// Properties for Router.
 #[derive(Properties)]
-pub struct Props<T: for<'de> RouterState<'de>, SW: Switch + 'static, M: 'static> {
+pub struct Props<T: for<'de> RouterState<'de>, SW: Switch + Clone + 'static, M: 'static> {
     /// Render function that
     #[props(required)]
     pub render: Render<T, SW, M>,
@@ -175,7 +175,7 @@ pub struct Props<T: for<'de> RouterState<'de>, SW: Switch + 'static, M: 'static>
     pub callback: Option<Callback<M>>,
 }
 
-impl<T: for<'de> RouterState<'de>, SW: Switch, M> Debug for Props<T, SW, M> {
+impl<T: for<'de> RouterState<'de>, SW: Switch + Clone, M> Debug for Props<T, SW, M> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
         f.debug_struct("Props").finish()
     }
@@ -184,7 +184,7 @@ impl<T: for<'de> RouterState<'de>, SW: Switch, M> Debug for Props<T, SW, M> {
 impl<T, SW, M> Component for Router<T, SW, M>
 where
     T: for<'de> RouterState<'de>,
-    SW: Switch + 'static,
+    SW: Switch + Clone + 'static,
     M: 'static,
 {
     type Message = Msg<T, M>;

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -10,7 +10,7 @@ use std::fmt::Write;
 /// # Example
 /// ```
 /// use yew_router::{route::Route, Switch};
-/// #[derive(Debug, Switch, PartialEq)]
+/// #[derive(Debug, Switch, Clone, PartialEq)]
 /// enum TestEnum {
 ///     #[to = "/test/route"]
 ///     TestRoute,
@@ -41,7 +41,7 @@ use std::fmt::Write;
 ///     Some(TestEnum::CaptureUnnamed("lorem".to_string()))
 /// );
 /// ```
-pub trait Switch: Sized {
+pub trait Switch: Clone + Sized {
     /// Based on a route, possibly produce an itself.
     fn switch<T: RouteState>(route: Route<T>) -> Option<Self> {
         Self::from_route_part(route).0

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -10,7 +10,7 @@ use std::fmt::Write;
 /// # Example
 /// ```
 /// use yew_router::{route::Route, Switch};
-/// #[derive(Debug, Switch, Clone, PartialEq)]
+/// #[derive(Debug, Switch, PartialEq)]
 /// enum TestEnum {
 ///     #[to = "/test/route"]
 ///     TestRoute,

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -41,7 +41,7 @@ use std::fmt::Write;
 ///     Some(TestEnum::CaptureUnnamed("lorem".to_string()))
 /// );
 /// ```
-pub trait Switch: Clone + Sized {
+pub trait Switch: Sized {
     /// Based on a route, possibly produce an itself.
     fn switch<T: RouteState>(route: Route<T>) -> Option<Self> {
         Self::from_route_part(route).0

--- a/tests/macro_test/src/lib.rs
+++ b/tests/macro_test/src/lib.rs
@@ -4,7 +4,7 @@ mod tests {
 
     #[test]
     fn single_enum_variant() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "/variant"]
             Variant,
@@ -16,7 +16,7 @@ mod tests {
 
     #[test]
     fn single_enum_variant_unnamed_without_corresponding_capture_group() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "/variant"]
             Variant(String),
@@ -35,7 +35,7 @@ mod tests {
 
     #[test]
     fn single_enum_variant_named_capture() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "/variant/{item}"]
             Variant { item: String },
@@ -52,7 +52,7 @@ mod tests {
 
     #[test]
     fn single_enum_variant_unnamed_capture() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "/variant/{item}"]
             Variant(String),
@@ -64,7 +64,7 @@ mod tests {
 
     #[test]
     fn single_enum_variant_multiple_unnamed_capture() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "/variant/{}/{}"] // For unnamed variants, the names don't matter at all
             Variant(String, String),
@@ -79,7 +79,7 @@ mod tests {
 
     #[test]
     fn single_enum_variant_multiple_named_capture() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "/variant/{item1}/{item2}"]
             Variant { item1: String, item2: String },
@@ -97,7 +97,7 @@ mod tests {
 
     #[test]
     fn single_enum_variant_named_capture_without_leading_separator() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "/variant{item}"]
             Variant { item: String },
@@ -114,7 +114,7 @@ mod tests {
 
     #[test]
     fn single_enum_variant_named_capture_without_any_separator() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "/variant{item}stuff"]
             Variant { item: String },
@@ -131,7 +131,7 @@ mod tests {
 
     #[test]
     fn single_enum_variant_end() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "/variant!"]
             Variant,
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn multiple_enum_variant_end_precedence() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "/variant!"]
             Variant1,
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn multiple_enum_variant_eager_matching() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "/variant"]
             Variant1,
@@ -178,7 +178,7 @@ mod tests {
 
     #[test]
     fn single_enum_variant_convert_usize() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "/variant/{item}"]
             Variant(usize),
@@ -190,7 +190,7 @@ mod tests {
 
     #[test]
     fn single_enum_variant_convert_usize_rejects_negative() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "/variant/{item}"]
             Variant(usize),
@@ -201,7 +201,7 @@ mod tests {
 
     #[test]
     fn single_enum_variant_convert_isize() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "/variant/{item}"]
             Variant(isize),
@@ -213,7 +213,7 @@ mod tests {
 
     #[test]
     fn single_enum_variant_missing_cap_produces_option_none() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "/variant"]
             Variant(Option<String>),
@@ -239,7 +239,7 @@ mod tests {
 
     #[test]
     fn leading_slash() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "/"]
             Variant,
@@ -251,7 +251,7 @@ mod tests {
 
     #[test]
     fn leading_named_capture() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "{cap}"]
             Variant(String),
@@ -263,7 +263,7 @@ mod tests {
 
     #[test]
     fn leading_unnamed_capture() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "{}"]
             Variant(String),
@@ -275,7 +275,7 @@ mod tests {
 
     #[test]
     fn leading_number_capture() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "{2:cap}"]
             Variant(String),
@@ -287,7 +287,7 @@ mod tests {
 
     #[test]
     fn leading_number_capture_unnamed() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "{2}"]
             Variant(String),
@@ -299,7 +299,7 @@ mod tests {
 
     #[test]
     fn leading_many_capture_named() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "{*:cap}"]
             Variant(String),
@@ -311,7 +311,7 @@ mod tests {
 
     #[test]
     fn leading_many_capture_unnamed() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "{*}"]
             Variant(String),
@@ -323,7 +323,7 @@ mod tests {
 
     #[test]
     fn leading_query_named() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "?query={hello}"]
             Variant(String),
@@ -335,7 +335,7 @@ mod tests {
 
     #[test]
     fn leading_query_unnamed() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "?query={}"]
             Variant(String),
@@ -347,7 +347,7 @@ mod tests {
 
     #[test]
     fn leading_fragment() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "#fragment"]
             Variant,
@@ -359,7 +359,7 @@ mod tests {
 
     #[test]
     fn fragment_with_named_captures() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "#{cap}ipsum{cap}"]
             Variant(String, String),
@@ -374,7 +374,7 @@ mod tests {
 
     #[test]
     fn fragment_with_unnamed_captures() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "#{}ipsum{}"]
             Variant(String, String),
@@ -389,7 +389,7 @@ mod tests {
 
     #[test]
     fn escape_exclaim() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "/escape!!"]
             Variant,
@@ -401,7 +401,7 @@ mod tests {
 
     #[test]
     fn escape_bracket() {
-        #[derive(Debug, Switch, PartialEq)]
+        #[derive(Debug, Switch, Clone, PartialEq)]
         pub enum Test {
             #[to = "/escape{{}}a"]
             Variant,


### PR DESCRIPTION
closes https://github.com/yewstack/yew_router/issues/171

Unfortunately this represents a breaking change, in that Switches must be Clone (EDIT: iff they are used in Router components) now.

A followup PR may change apis to rely on references or Option::take instead of cloning, but those changes would represent breakages as well.