### PR TITLE
Remove unused expected tokens

### DIFF
--- a/crates/yew_router_route_parser/src/error.rs
+++ b/crates/yew_router_route_parser/src/error.rs
@@ -141,13 +141,8 @@ impl fmt::Display for ExpectedToken {
         match self {
             ExpectedToken::Separator => f.write_str("/"),
             ExpectedToken::Literal => f.write_str("<literal>"),
-//            ExpectedToken::CaptureNamed => f.write_str("{<number>:<ident>}"),
-//            ExpectedToken::CaptureNumberedNamed => f.write_str("{<number>:<ident>}"),
-//            ExpectedToken::CaptureManyNamed => f.write_str("{*:<ident>}"),
             ExpectedToken::QueryBegin => f.write_str("?"),
             ExpectedToken::QuerySeparator => f.write_str("&"),
-//            ExpectedToken::QueryCapture => f.write_str("<literal>={<ident>}"),
-//            ExpectedToken::QueryLiteral => f.write_str("<literal>=<literal>"),
             ExpectedToken::FragmentBegin => f.write_str("#"),
             ExpectedToken::End => f.write_str("!"),
             ExpectedToken::Ident => f.write_str("<ident>"),

--- a/crates/yew_router_route_parser/src/error.rs
+++ b/crates/yew_router_route_parser/src/error.rs
@@ -114,20 +114,10 @@ pub enum ExpectedToken {
     Separator,
     /// specific string.
     Literal,
-    ///  {name}.
-    CaptureNamed,
-    // {5:name}
-    CaptureNumberedNamed,
-    // {*:name}
-    CaptureManyNamed,
     ///  ?
     QueryBegin,
     ///  &
     QuerySeparator,
-    ///  x={y}
-    QueryCapture,
-    // x=y
-    QueryLiteral,
     /// \#
     FragmentBegin,
     /// !
@@ -151,13 +141,13 @@ impl fmt::Display for ExpectedToken {
         match self {
             ExpectedToken::Separator => f.write_str("/"),
             ExpectedToken::Literal => f.write_str("<literal>"),
-            ExpectedToken::CaptureNamed => f.write_str("{<number>:<ident>}"),
-            ExpectedToken::CaptureNumberedNamed => f.write_str("{<number>:<ident>}"),
-            ExpectedToken::CaptureManyNamed => f.write_str("{*:<ident>}"),
+//            ExpectedToken::CaptureNamed => f.write_str("{<number>:<ident>}"),
+//            ExpectedToken::CaptureNumberedNamed => f.write_str("{<number>:<ident>}"),
+//            ExpectedToken::CaptureManyNamed => f.write_str("{*:<ident>}"),
             ExpectedToken::QueryBegin => f.write_str("?"),
             ExpectedToken::QuerySeparator => f.write_str("&"),
-            ExpectedToken::QueryCapture => f.write_str("<literal>={<ident>}"),
-            ExpectedToken::QueryLiteral => f.write_str("<literal>=<literal>"),
+//            ExpectedToken::QueryCapture => f.write_str("<literal>={<ident>}"),
+//            ExpectedToken::QueryLiteral => f.write_str("<literal>=<literal>"),
             ExpectedToken::FragmentBegin => f.write_str("#"),
             ExpectedToken::End => f.write_str("!"),
             ExpectedToken::Ident => f.write_str("<ident>"),

--- a/src/matcher/mod.rs
+++ b/src/matcher/mod.rs
@@ -46,7 +46,7 @@ impl RouteMatcher {
         Ok(RouteMatcher {
             tokens: parse_str_and_optimize_tokens(
                 i,
-                yew_router_route_parser::FieldNamingScheme::Unnamed,
+                yew_router_route_parser::FieldNamingScheme::Unnamed, // The most permissive scheme
             )?, /* TODO this field type should be a superset of Named, but it would be better to source this from settings, and make sure that the macro generates settings as such. */
             settings,
         })
@@ -192,7 +192,6 @@ mod tests {
             .expect_err("should not parse");
     }
 
-    // TODO fix this test
     #[test]
     fn match_n() {
         let tokens = vec![


### PR DESCRIPTION
The code used for generating expected tokens when the parser fails doesn't ever create a few legacy expected tokens. 
This PR removes them.