### PR TITLE
Adjust parser to accept Path and Query specific characters in Fragments

### DIFF
--- a/crates/yew_router_route_parser/src/core.rs
+++ b/crates/yew_router_route_parser/src/core.rs
@@ -321,8 +321,8 @@ mod test {
 
     #[test]
     fn lit() {
-        let x = exact_impl("hello").expect("Should parse");
-        assert_eq!(x.1, "hello")
+        let x = exact("hello").expect("Should parse");
+        assert_eq!(x.1, RouteParserToken::Exact("hello"))
     }
 
     #[test]

--- a/crates/yew_router_route_parser/src/parser.rs
+++ b/crates/yew_router_route_parser/src/parser.rs
@@ -7,6 +7,7 @@ use crate::{
     FieldNamingScheme,
 };
 use nom::{branch::alt, IResult};
+use crate::core::fragment_exact;
 // use crate::core::escaped_item;
 
 /// Tokens generated from parsing a route matcher string.
@@ -384,10 +385,10 @@ fn parse_impl<'a>(
         },
         ParserState::Fragment { prev_token } => match prev_token {
             RouteParserToken::FragmentBegin => {
-                alt((exact, capture_single(field_naming_scheme), get_end))(i)
+                alt((fragment_exact, capture_single(field_naming_scheme), get_end))(i)
             }
             RouteParserToken::Exact(_) => alt((capture_single(field_naming_scheme), get_end))(i),
-            RouteParserToken::Capture(_) => alt((exact, get_end))(i),
+            RouteParserToken::Capture(_) => alt((fragment_exact, get_end))(i),
             _ => Err(nom::Err::Failure(ParseError {
                 reason: Some(ParserErrorReason::InvalidState),
                 expected: vec![],

--- a/tests/macro_test/src/lib.rs
+++ b/tests/macro_test/src/lib.rs
@@ -410,4 +410,44 @@ mod tests {
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant)
     }
+
+    mod fragment_routing_tests {
+        use super::*;
+
+        #[test]
+        fn basic_fragment() {
+            #[derive(Debug, Switch, Clone, PartialEq)]
+            pub enum Test {
+                #[to = "#/lorem"]
+                Variant,
+            }
+            let route = Route::from("#/lorem");
+            Test::switch(route).expect("should produce item");
+        }
+
+        #[test]
+        fn query_within_fragment() {
+            #[derive(Debug, Switch, Clone, PartialEq)]
+            pub enum Test {
+                #[to = "#/lorem=ipsum"]
+                Variant,
+            }
+            let route = Route::from("#/lorem=ipsum");
+            Test::switch(route).expect("should produce item");
+        }
+
+        #[test]
+        fn capture_query_within_fragment() {
+            #[derive(Debug, Switch, Clone, PartialEq)]
+            pub enum Test {
+                #[to = "#/lorem={ipsum}"]
+                Variant{ipsum: String},
+            }
+            let route = Route::from("#/lorem=dolor");
+            let switched = Test::switch(route).expect("should produce item");
+            assert_eq!(switched, Test::Variant{ipsum: "dolor".to_string()})
+        }
+    }
 }
+
+


### PR DESCRIPTION
Closes https://github.com/yewstack/yew_router/issues/150

This should enable fragment routing.