### PR TITLE
Add a warp example for 404 path-preserving redirection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,5 +45,6 @@ members = [
     "examples/guide",
     "examples/switch",
     "examples/minimal",
+    "examples/servers/warp",
     "tests/macro_test"
 ]

--- a/examples/servers/Readme.md
+++ b/examples/servers/Readme.md
@@ -1,0 +1,34 @@
+# Example Servers
+
+These servers allow you to serve your application from any non-api route.
+This should prevent you from seeing 404 errors when refreshing your app after changing the route.
+
+It rely on having the project already built/deployed by cargo-web, with some modifications to the output to ensure correctness.
+
+## Instructions
+
+Run `cargo web deploy` from the `/examples/router_component` folder to build the project that will be served by a server here.
+Then, navigate to the `/target/deploy/` directory and run:
+```sh
+sed -i 's/router_component.wasm/\/router_component.wasm/g' router_component.js
+```
+and
+```sh
+sed -i 's/router_component.js/\/router_component.js/g' index.html
+```
+If these commands aren't ran, then the server will serve the wrong files when it tries to get a compound path.
+For example, if you request "/some/path" because it will serve `index.html`'s content, but then the request for the "router_component.js" it makes will attempt to get it from "/some/router_component.js", which doesn't exist.
+These replacements make the browser get the path from the absolute path, so it will always get the correct item.
+
+Then go to your chosen server and run `cargo run` to start it.
+
+## As a template
+
+You can use these as templates for your server, or incorporate them into an existing server.
+You will likely have to change the assets dir constant to point elsewhere though.
+```rust
+    const ASSETS_DIR: &str = "your/assets/dir/here";
+```
+
+### Non-cargo-web
+The instructions for using `sed` and `cargo-web` above are irrelevant if you use these server templates for apps built with parcel or webpack.

--- a/examples/servers/warp/Cargo.toml
+++ b/examples/servers/warp/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "warp"
+version = "0.1.0"
+authors = ["Henry Zimmerman <zimhen7@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+warp = "0.1.20"

--- a/examples/servers/warp/src/main.rs
+++ b/examples/servers/warp/src/main.rs
@@ -1,0 +1,71 @@
+use std::path::{PathBuf};
+use warp::filters::BoxedFilter;
+use warp::{Reply, Filter};
+use warp::path::Peek;
+use warp::fs::File;
+use warp::path;
+
+fn main() {
+
+    let localhost = [0, 0, 0, 0];
+    let port = 8000;
+    let addr = (localhost, port);
+
+    // You will need to change this if you use this as a template for your application.
+
+    const ASSETS_DIR: &str = "../../../target/deploy";
+    let assets_dir: PathBuf = PathBuf::from(ASSETS_DIR);
+
+    let routes = api()
+        .or(static_files_handler(assets_dir));
+
+    warp::serve(routes).run(addr);
+}
+
+const API_STRING: &str = "api";
+
+pub fn api() -> BoxedFilter<(impl Reply,)> {
+    warp::path(API_STRING)
+        .and(path!(String))
+        .and(warp::get2())
+        .map(std::convert::identity) // Echos the string back in the response body
+        .boxed()
+}
+
+/// Expose filters that work with static files
+pub fn static_files_handler(assets_dir: PathBuf) -> BoxedFilter<(impl Reply,)> {
+    const INDEX_HTML: &str = "index.html";
+
+    let files = assets(assets_dir.clone())
+        .or(index_static_file_redirect(assets_dir.join(INDEX_HTML)));
+
+    warp::any()
+        .and(files)
+        .boxed()
+}
+
+/// If the path does not start with /api, return the index.html, so the app will bootstrap itself
+/// regardless of whatever the frontend-specific path is.
+fn index_static_file_redirect(index_file_path: PathBuf) -> BoxedFilter<(impl Reply,)> {
+    warp::get2()
+        .and(warp::path::peek())
+        .and(warp::fs::file(index_file_path))
+        .and_then(|segments: Peek, file: File| {
+            // Reject the request if the path starts with /api/
+            if let Some(first_segment) = segments.segments().next() {
+                if first_segment == API_STRING {
+                    return Err(warp::reject::not_found())
+                }
+            }
+            Ok(file)
+        })
+        .boxed()
+}
+
+/// Gets the file within the specified dir.
+fn assets(dir_path: PathBuf) -> BoxedFilter<(impl Reply,)> {
+    warp::get2()
+        .and(warp::fs::dir(dir_path))
+        .and(warp::path::end())
+        .boxed()
+}


### PR DESCRIPTION
Completes the warp section of https://github.com/yewstack/yew_router/issues/187