### PR TITLE
Add unit as the default state type

### DIFF
--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -6,7 +6,10 @@ use crate::switch::{
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;
-use syn::{export::TokenStream2, parse_macro_input, Data, DeriveInput, Fields, Ident, Variant, Generics, GenericParam};
+use syn::{
+    export::TokenStream2, parse_macro_input, Data, DeriveInput, Fields, GenericParam, Generics,
+    Ident, Variant,
+};
 
 mod attribute;
 mod enum_impl;
@@ -14,8 +17,8 @@ mod shadow;
 mod struct_impl;
 
 use self::attribute::AttrToken;
-use yew_router_route_parser::FieldNamingScheme;
 use syn::punctuated::Punctuated;
+use yew_router_route_parser::FieldNamingScheme;
 
 /// Holds data that is required to derive Switch for a struct or a single enum variant.
 pub struct SwitchItem {
@@ -308,7 +311,7 @@ pub fn impl_line(ident: &Ident, generics: &Generics) -> TokenStream2 {
             .collect::<Punctuated<_,syn::token::Comma>>();
 
         let where_clause = &generics.where_clause;
-        quote!{
+        quote! {
             impl <#params> ::yew_router::Switch for #ident <#param_idents> #where_clause
         }
     }

--- a/crates/yew_router_macro/src/switch/enum_impl.rs
+++ b/crates/yew_router_macro/src/switch/enum_impl.rs
@@ -1,10 +1,14 @@
-use crate::switch::{build_serializer_for_enum, SwitchItem, impl_line};
+use crate::switch::{build_serializer_for_enum, impl_line, SwitchItem};
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;
-use syn::{export::TokenStream2, Field, Fields, Ident, Type, Generics};
+use syn::{export::TokenStream2, Field, Fields, Generics, Ident, Type};
 
-pub fn generate_enum_impl(enum_ident: Ident, switch_variants: Vec<SwitchItem>, generics: Generics) -> TokenStream {
+pub fn generate_enum_impl(
+    enum_ident: Ident,
+    switch_variants: Vec<SwitchItem>,
+    generics: Generics,
+) -> TokenStream {
     let variant_matchers = switch_variants.iter().map(|sv| {
         let SwitchItem {
             matcher,

--- a/crates/yew_router_macro/src/switch/struct_impl.rs
+++ b/crates/yew_router_macro/src/switch/struct_impl.rs
@@ -1,8 +1,10 @@
-use crate::switch::{SwitchItem, impl_line};
+use crate::switch::{impl_line, SwitchItem};
 use proc_macro2::{Ident, Span};
 use quote::quote;
-use syn::{export::{TokenStream, TokenStream2}, Field, Fields, Type, Generics};
-
+use syn::{
+    export::{TokenStream, TokenStream2},
+    Field, Fields, Generics, Type,
+};
 
 
 pub fn generate_struct_impl(item: SwitchItem, generics: Generics) -> TokenStream {

--- a/examples/servers/warp/src/main.rs
+++ b/examples/servers/warp/src/main.rs
@@ -2,8 +2,7 @@ use std::path::PathBuf;
 use warp::{
     filters::BoxedFilter,
     fs::File,
-    path::{Peek},
-    path,
+    path::{self, Peek},
     Filter, Reply,
 };
 

--- a/examples/switch/src/main.rs
+++ b/examples/switch/src/main.rs
@@ -103,8 +103,7 @@ pub struct OtherSingle(u32);
 
 #[derive(Switch, Debug, Clone)]
 #[to = "{*:path}#{route}"]
-pub struct FragmentAdapter<W: Switch>{
+pub struct FragmentAdapter<W: Switch> {
     path: String,
-    route: W
+    route: W,
 }
-

--- a/src/agent/bridge.rs
+++ b/src/agent/bridge.rs
@@ -15,7 +15,7 @@ use yew::{
 /// A wrapped bridge to the route agent.
 ///
 /// A component that owns this can send and receive messages from the agent.
-pub struct RouteAgentBridge<T>(Box<dyn Bridge<RouteAgent<T>>>)
+pub struct RouteAgentBridge<T = ()>(Box<dyn Bridge<RouteAgent<T>>>)
 where
     for<'de> T: AgentState<'de>;
 

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -9,7 +9,7 @@ use yew::agent::{Dispatched, Dispatcher};
 /// A wrapped dispatcher to the route agent.
 ///
 /// A component that owns and instance of this can send messages to the RouteAgent, but not receive them.
-pub struct RouteAgentDispatcher<T>(Dispatcher<RouteAgent<T>>)
+pub struct RouteAgentDispatcher<T = ()>(Dispatcher<RouteAgent<T>>)
 where
     for<'de> T: AgentState<'de>;
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -33,7 +33,7 @@ pub enum Msg<T> {
 
 /// Input message type for interacting with the `RouteAgent'.
 #[derive(Serialize, Deserialize, Debug)]
-pub enum RouteRequest<T> {
+pub enum RouteRequest<T = ()> {
     /// Replaces the most recent Route with a new one and alerts connected components to the route
     /// change.
     ReplaceRoute(Route<T>),
@@ -59,7 +59,7 @@ pub enum RouteRequest<T> {
 ///
 /// If you use multiple agents with different types, then the Agents won't be able to communicate to
 /// each other and associated components may not work as intended.
-pub struct RouteAgent<T>
+pub struct RouteAgent<T = ()>
 where
     for<'de> T: AgentState<'de>,
 {
@@ -88,10 +88,10 @@ impl<T> Agent for RouteAgent<T>
 where
     for<'de> T: AgentState<'de>,
 {
-    type Input = RouteRequest<T>;
-    type Message = Msg<T>;
-    type Output = Route<T>;
     type Reach = Context;
+    type Message = Msg<T>;
+    type Input = RouteRequest<T>;
+    type Output = Route<T>;
 
     fn create(link: AgentLink<RouteAgent<T>>) -> Self {
         let callback = link.callback(Msg::BrowserNavigationRouteChanged);

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -88,10 +88,10 @@ impl<T> Agent for RouteAgent<T>
 where
     for<'de> T: AgentState<'de>,
 {
-    type Reach = Context;
-    type Message = Msg<T>;
     type Input = RouteRequest<T>;
+    type Message = Msg<T>;
     type Output = Route<T>;
+    type Reach = Context;
 
     fn create(link: AgentLink<RouteAgent<T>>) -> Self {
         let callback = link.callback(Msg::BrowserNavigationRouteChanged);

--- a/src/components/router_button.rs
+++ b/src/components/router_button.rs
@@ -11,7 +11,7 @@ use yew::virtual_dom::VNode;
 
 /// Changes the route when clicked.
 #[derive(Debug)]
-pub struct RouterButton<T: for<'de> RouterState<'de>> {
+pub struct RouterButton<T: for<'de> RouterState<'de> = ()> {
     link: ComponentLink<Self>,
     router: RouteAgentDispatcher<T>,
     props: Props<T>,

--- a/src/components/router_link.rs
+++ b/src/components/router_link.rs
@@ -17,7 +17,7 @@ pub type RouterLink<T> = RouterAnchor<T>;
 
 /// An anchor tag Component that when clicked, will navigate to the provided route.
 #[derive(Debug)]
-pub struct RouterAnchor<T: for<'de> RouterState<'de>> {
+pub struct RouterAnchor<T: for<'de> RouterState<'de> = ()> {
     link: ComponentLink<Self>,
     router: RouteAgentDispatcher<T>,
     props: Props<T>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,22 @@ pub mod unit_state {
 /// Prelude module that can be imported when working with the yew_router
 pub mod prelude {
     pub use super::matcher::Captures;
-    #[cfg(feature = "unit_alias")]
-    pub use super::unit_state::*;
+
+    pub use crate::route::Route;
+    pub use crate::service::RouteService;
+    #[cfg(feature="agent")]
+    pub use crate::agent::RouteAgent;
+    #[cfg(feature="agent")]
+    pub use crate::agent::RouteAgentBridge;
+    #[cfg(feature="agent")]
+    pub use crate::agent::RouteAgentDispatcher;
+    #[cfg(feature="components")]
+    pub use crate::components::RouterAnchor;
+    #[cfg(feature="components")]
+    pub use crate::components::RouterButton;
+    #[cfg(feature="router")]
+    pub use crate::router::Router;
+
     pub use crate::switch::Switch;
     pub use yew_router_macro::Switch;
     // State restrictions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,20 +83,19 @@ pub mod unit_state {
 pub mod prelude {
     pub use super::matcher::Captures;
 
-    pub use crate::route::Route;
-    pub use crate::service::RouteService;
-    #[cfg(feature="agent")]
+    #[cfg(feature = "agent")]
     pub use crate::agent::RouteAgent;
-    #[cfg(feature="agent")]
+    #[cfg(feature = "agent")]
     pub use crate::agent::RouteAgentBridge;
-    #[cfg(feature="agent")]
+    #[cfg(feature = "agent")]
     pub use crate::agent::RouteAgentDispatcher;
-    #[cfg(feature="components")]
+    #[cfg(feature = "components")]
     pub use crate::components::RouterAnchor;
-    #[cfg(feature="components")]
+    #[cfg(feature = "components")]
     pub use crate::components::RouterButton;
-    #[cfg(feature="router")]
+    #[cfg(feature = "router")]
     pub use crate::router::Router;
+    pub use crate::{route::Route, service::RouteService};
 
     pub use crate::switch::Switch;
     pub use yew_router_macro::Switch;

--- a/src/route.rs
+++ b/src/route.rs
@@ -10,7 +10,7 @@ impl<T> RouteState for T where T: Clone + Default + JsSerialize + TryFrom<Value>
 
 /// The representation of a route, segmented into different sections for easy access.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct Route<T> {
+pub struct Route<T = ()> {
     /// The route string
     pub route: String,
     /// The state stored in the history api

--- a/src/router.rs
+++ b/src/router.rs
@@ -40,7 +40,7 @@ impl<'de, T> RouterState<'de> for T where T: AgentState<'de> + PartialEq {}
 ///
 ///     fn view(&self) -> VNode {
 ///         html! {
-///         <Router<(), S>
+///         <Router<S>
 ///            render = Router::render(|switch: S| {
 ///                match switch {
 ///                    S::Variant => html!{"variant route was matched"},
@@ -85,7 +85,7 @@ where
     /// # pub enum Msg {}
     ///
     /// # fn dont_execute() {
-    /// let render: Render<(), S> = Router::render(|switch: S| -> Html {
+    /// let render: Render<S> = Router::render(|switch: S| -> Html {
     ///     match switch {
     ///         S::Variant => html! {"Variant"},
     ///     }

--- a/src/router.rs
+++ b/src/router.rs
@@ -59,13 +59,13 @@ impl<'de, T> RouterState<'de> for T where T: AgentState<'de> + PartialEq {}
 /// ```
 // TODO, can M just be removed due to not having to explicitly deal with callbacks anymore? - Just get rid of M
 #[derive(Debug)]
-pub struct Router<T: for<'de> RouterState<'de>, SW: Switch + Clone + 'static> {
+pub struct Router<SW: Switch + Clone + 'static, T: for<'de> RouterState<'de> = ()> {
     switch: Option<SW>,
     props: Props<T, SW>,
     router_agent: RouteAgentBridge<T>,
 }
 
-impl<T, SW> Router<T, SW>
+impl<SW, T> Router<SW, T>
 where
     T: for<'de> RouterState<'de>,
     SW: Switch + Clone + 'static,
@@ -92,7 +92,7 @@ where
     /// });
     /// # }
     /// ```
-    pub fn render<F: RenderFn<Router<T, SW>, SW> + 'static>(f: F) -> Render<T, SW> {
+    pub fn render<F: RenderFn<Router<SW, T>, SW> + 'static>(f: F) -> Render<SW, T> {
         Render::new(f)
     }
 
@@ -114,16 +114,16 @@ pub trait RenderFn<CTX: Component, SW>: Fn(SW) -> Html {}
 impl<T, CTX: Component, SW> RenderFn<CTX, SW> for T where T: Fn(SW) -> Html {}
 /// Owned Render function.
 #[derive(Clone)]
-pub struct Render<T: for<'de> RouterState<'de>, SW: Switch + Clone + 'static>(
-    pub(crate) Rc<dyn RenderFn<Router<T, SW>, SW>>,
+pub struct Render<SW: Switch + Clone + 'static, T: for<'de> RouterState<'de> = ()>(
+    pub(crate) Rc<dyn RenderFn<Router<SW, T>, SW>>,
 );
-impl<T: for<'de> RouterState<'de>, SW: Switch + Clone> Render<T, SW> {
+impl<T: for<'de> RouterState<'de>, SW: Switch + Clone> Render<SW, T> {
     /// New render function
-    fn new<F: RenderFn<Router<T, SW>, SW> + 'static>(f: F) -> Self {
+    fn new<F: RenderFn<Router<SW, T>, SW> + 'static>(f: F) -> Self {
         Render(Rc::new(f))
     }
 }
-impl<T: for<'de> RouterState<'de>, SW: Switch + Clone> Debug for Render<T, SW> {
+impl<T: for<'de> RouterState<'de>, SW: Switch + Clone> Debug for Render<SW, T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("Render").finish()
     }
@@ -154,7 +154,7 @@ impl<STATE: for<'de> RouterState<'de>, SW: Switch> Debug for Redirect<SW, STATE>
 pub struct Props<T: for<'de> RouterState<'de>, SW: Switch + Clone + 'static> {
     /// Render function that takes a Switch and produces Html
     #[props(required)]
-    pub render: Render<T, SW>,
+    pub render: Render<SW, T>,
     /// Optional redirect function that will convert the route to a known switch variant if explicit matching fails.
     /// This should mostly be used to handle 404s and redirection.
     /// It is not strictly necessary as your Switch is capable of handling unknown routes using `#[to="/{*:any}"]`.
@@ -167,7 +167,7 @@ impl<T: for<'de> RouterState<'de>, SW: Switch + Clone> Debug for Props<T, SW> {
     }
 }
 
-impl<T, SW> Component for Router<T, SW>
+impl<T, SW> Component for Router<SW, T>
 where
     T: for<'de> RouterState<'de>,
     SW: Switch + Clone + 'static,

--- a/src/service.rs
+++ b/src/service.rs
@@ -14,11 +14,10 @@ use std::marker::PhantomData;
 ///
 /// The `T` determines what route state can be stored in the route service.
 #[derive(Debug)]
-pub struct RouteService<T> {
+pub struct RouteService<T = ()> {
     history: History,
     location: Location,
     event_listener: Option<EventListenerHandle>,
-
     phantom_data: PhantomData<T>,
 }
 

--- a/tests/macro_test/src/lib.rs
+++ b/tests/macro_test/src/lib.rs
@@ -9,7 +9,7 @@ mod tests {
             #[to = "/variant"]
             Variant,
         }
-        let route = Route::from("/variant");
+        let route: Route = Route::from("/variant");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant)
     }
@@ -21,12 +21,12 @@ mod tests {
             #[to = "/variant"]
             Variant(String),
         }
-        let route = Route::from("/variant");
+        let route: Route = Route::from("/variant");
         assert!(
             Test::switch(route).is_none(),
             "there should not be a way to ever create this variant."
         );
-        let route = Route::from("/variant/some/stuff");
+        let route: Route = Route::from("/variant/some/stuff");
         assert!(
             Test::switch(route).is_none(),
             "there should not be a way to ever create this variant."
@@ -40,7 +40,7 @@ mod tests {
             #[to = "/variant/{item}"]
             Variant { item: String },
         }
-        let route = Route::from("/variant/thing");
+        let route: Route = Route::from("/variant/thing");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(
             switched,
@@ -57,7 +57,7 @@ mod tests {
             #[to = "/variant/{item}"]
             Variant(String),
         }
-        let route = Route::from("/variant/thing");
+        let route: Route = Route::from("/variant/thing");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant("thing".to_string()))
     }
@@ -69,7 +69,7 @@ mod tests {
             #[to = "/variant/{}/{}"] // For unnamed variants, the names don't matter at all
             Variant(String, String),
         }
-        let route = Route::from("/variant/thing/other");
+        let route: Route = Route::from("/variant/thing/other");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(
             switched,
@@ -84,7 +84,7 @@ mod tests {
             #[to = "/variant/{item1}/{item2}"]
             Variant { item1: String, item2: String },
         }
-        let route = Route::from("/variant/thing/other");
+        let route: Route = Route::from("/variant/thing/other");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(
             switched,
@@ -102,7 +102,7 @@ mod tests {
             #[to = "/variant{item}"]
             Variant { item: String },
         }
-        let route = Route::from("/variantthing");
+        let route: Route = Route::from("/variantthing");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(
             switched,
@@ -119,7 +119,7 @@ mod tests {
             #[to = "/variant{item}stuff"]
             Variant { item: String },
         }
-        let route = Route::from("/variantthingstuff");
+        let route: Route = Route::from("/variantthingstuff");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(
             switched,
@@ -136,7 +136,7 @@ mod tests {
             #[to = "/variant!"]
             Variant,
         }
-        let route = Route::from("/variant/");
+        let route: Route = Route::from("/variant/");
         assert!(Test::switch(route).is_none());
     }
 
@@ -149,7 +149,7 @@ mod tests {
             #[to = "/variant/stuff"]
             Variant2,
         }
-        let route = Route::from("/variant/stuff");
+        let route: Route = Route::from("/variant/stuff");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(
             switched,
@@ -167,7 +167,7 @@ mod tests {
             #[to = "/variant/stuff"]
             Variant2,
         }
-        let route = Route::from("/variant/stuff");
+        let route: Route = Route::from("/variant/stuff");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(
             switched,
@@ -183,7 +183,7 @@ mod tests {
             #[to = "/variant/{item}"]
             Variant(usize),
         }
-        let route = Route::from("/variant/42");
+        let route: Route = Route::from("/variant/42");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant(42))
     }
@@ -195,7 +195,7 @@ mod tests {
             #[to = "/variant/{item}"]
             Variant(usize),
         }
-        let route = Route::from("/variant/-42");
+        let route: Route = Route::from("/variant/-42");
         assert!(Test::switch(route).is_none());
     }
 
@@ -206,7 +206,7 @@ mod tests {
             #[to = "/variant/{item}"]
             Variant(isize),
         }
-        let route = Route::from("/variant/-42");
+        let route: Route = Route::from("/variant/-42");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant(-42))
     }
@@ -218,7 +218,7 @@ mod tests {
             #[to = "/variant"]
             Variant(Option<String>),
         }
-        let route = Route::from("/variant");
+        let route: Route = Route::from("/variant");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant(None))
     }
@@ -244,7 +244,7 @@ mod tests {
             #[to = "/"]
             Variant,
         }
-        let route = Route::from("/");
+        let route: Route = Route::from("/");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant)
     }
@@ -256,7 +256,7 @@ mod tests {
             #[to = "{cap}"]
             Variant(String),
         }
-        let route = Route::from("hello");
+        let route: Route = Route::from("hello");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant("hello".to_string()))
     }
@@ -268,7 +268,7 @@ mod tests {
             #[to = "{}"]
             Variant(String),
         }
-        let route = Route::from("hello");
+        let route: Route = Route::from("hello");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant("hello".to_string()))
     }
@@ -280,7 +280,7 @@ mod tests {
             #[to = "{2:cap}"]
             Variant(String),
         }
-        let route = Route::from("hello/there");
+        let route: Route = Route::from("hello/there");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant("hello/there".to_string()))
     }
@@ -292,7 +292,7 @@ mod tests {
             #[to = "{2}"]
             Variant(String),
         }
-        let route = Route::from("hello/there");
+        let route: Route = Route::from("hello/there");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant("hello/there".to_string()))
     }
@@ -304,7 +304,7 @@ mod tests {
             #[to = "{*:cap}"]
             Variant(String),
         }
-        let route = Route::from("hello/there");
+        let route: Route = Route::from("hello/there");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant("hello/there".to_string()))
     }
@@ -316,7 +316,7 @@ mod tests {
             #[to = "{*}"]
             Variant(String),
         }
-        let route = Route::from("hello/there");
+        let route: Route = Route::from("hello/there");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant("hello/there".to_string()))
     }
@@ -328,7 +328,7 @@ mod tests {
             #[to = "?query={hello}"]
             Variant(String),
         }
-        let route = Route::from("?query=lorem");
+        let route: Route = Route::from("?query=lorem");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant("lorem".to_string()))
     }
@@ -340,7 +340,7 @@ mod tests {
             #[to = "?query={}"]
             Variant(String),
         }
-        let route = Route::from("?query=lorem");
+        let route: Route = Route::from("?query=lorem");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant("lorem".to_string()))
     }
@@ -352,7 +352,7 @@ mod tests {
             #[to = "#fragment"]
             Variant,
         }
-        let route = Route::from("#fragment");
+        let route: Route = Route::from("#fragment");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant)
     }
@@ -364,7 +364,7 @@ mod tests {
             #[to = "#{cap}ipsum{cap}"]
             Variant(String, String),
         }
-        let route = Route::from("#loremipsumdolor");
+        let route: Route = Route::from("#loremipsumdolor");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(
             switched,
@@ -379,7 +379,7 @@ mod tests {
             #[to = "#{}ipsum{}"]
             Variant(String, String),
         }
-        let route = Route::from("#loremipsumdolor");
+        let route: Route = Route::from("#loremipsumdolor");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(
             switched,
@@ -394,7 +394,7 @@ mod tests {
             #[to = "/escape!!"]
             Variant,
         }
-        let route = Route::from("/escape!");
+        let route: Route = Route::from("/escape!");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant)
     }
@@ -406,7 +406,7 @@ mod tests {
             #[to = "/escape{{}}a"]
             Variant,
         }
-        let route = Route::from("/escape{}a");
+        let route: Route = Route::from("/escape{}a");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant)
     }
@@ -421,7 +421,7 @@ mod tests {
                 #[to = "#/lorem"]
                 Variant,
             }
-            let route = Route::from("#/lorem");
+            let route: Route = Route::from("#/lorem");
             Test::switch(route).expect("should produce item");
         }
 
@@ -432,7 +432,7 @@ mod tests {
                 #[to = "#/lorem=ipsum"]
                 Variant,
             }
-            let route = Route::from("#/lorem=ipsum");
+            let route: Route = Route::from("#/lorem=ipsum");
             Test::switch(route).expect("should produce item");
         }
 
@@ -443,7 +443,7 @@ mod tests {
                 #[to = "#/lorem={ipsum}"]
                 Variant { ipsum: String },
             }
-            let route = Route::from("#/lorem=dolor");
+            let route: Route = Route::from("#/lorem=dolor");
             let switched = Test::switch(route).expect("should produce item");
             assert_eq!(
                 switched,


### PR DESCRIPTION
Prior to this PR, a macro was used to set the state type for items in this crate. 
Now, the unit type `()` is set to be the default type for these items, which removes reliance on the problematic macro.

Closes https://github.com/yewstack/yew_router/issues/157