### PR TITLE
Store state as a serialized string

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ yew-router-route-parser = {path = "crates/yew_router_route_parser", version = "0
 yew-router-macro = {path = "crates/yew_router_macro", version = "0.8.0"}
 nom = "5.0.1"
 uuid = "0.8.1"
+serde_json = "1.0.44"
 
 
 

--- a/examples/servers/warp/src/main.rs
+++ b/examples/servers/warp/src/main.rs
@@ -1,8 +1,11 @@
 use std::path::PathBuf;
+
+#[rustfmt::skip]
 use warp::{
     filters::BoxedFilter,
     fs::File,
-    path::{self, Peek},
+    path::Peek,
+    path,
     Filter, Reply,
 };
 

--- a/src/agent/bridge.rs
+++ b/src/agent/bridge.rs
@@ -1,8 +1,5 @@
 //! Bridge to RouteAgent.
-use crate::{
-    agent::{AgentState, RouteAgent},
-    route::Route,
-};
+use crate::{agent::{RouteAgent}, route::Route, RouteState};
 use std::{
     fmt::{Debug, Error as FmtError, Formatter},
     ops::{Deref, DerefMut},
@@ -17,11 +14,11 @@ use yew::{
 /// A component that owns this can send and receive messages from the agent.
 pub struct RouteAgentBridge<T = ()>(Box<dyn Bridge<RouteAgent<T>>>)
 where
-    for<'de> T: AgentState<'de>;
+    T: RouteState;
 
 impl<T> RouteAgentBridge<T>
 where
-    for<'de> T: AgentState<'de>,
+    T: RouteState,
 {
     /// Creates a new bridge.
     pub fn new(callback: Callback<Route<T>>) -> Self {
@@ -39,20 +36,20 @@ where
     }
 }
 
-impl<T: for<'de> AgentState<'de>> Debug for RouteAgentBridge<T> {
+impl<T: RouteState> Debug for RouteAgentBridge<T> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
         f.debug_tuple("RouteAgentBridge").finish()
     }
 }
 
-impl<T: for<'de> AgentState<'de>> Deref for RouteAgentBridge<T> {
+impl<T: RouteState> Deref for RouteAgentBridge<T> {
     type Target = Box<dyn Bridge<RouteAgent<T>>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
-impl<T: for<'de> AgentState<'de>> DerefMut for RouteAgentBridge<T> {
+impl<T: RouteState> DerefMut for RouteAgentBridge<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -1,21 +1,22 @@
 //! Dispatcher to RouteAgent.
-use crate::agent::{AgentState, RouteAgent};
+use crate::agent::{RouteAgent};
 use std::{
     fmt::{Debug, Error as FmtError, Formatter},
     ops::{Deref, DerefMut},
 };
 use yew::agent::{Dispatched, Dispatcher};
+use crate::RouteState;
 
 /// A wrapped dispatcher to the route agent.
 ///
 /// A component that owns and instance of this can send messages to the RouteAgent, but not receive them.
 pub struct RouteAgentDispatcher<T = ()>(Dispatcher<RouteAgent<T>>)
 where
-    for<'de> T: AgentState<'de>;
+    T: RouteState;
 
 impl<T> RouteAgentDispatcher<T>
 where
-    for<'de> T: AgentState<'de>,
+    T: RouteState
 {
     /// Creates a new bridge.
     pub fn new() -> Self {
@@ -26,27 +27,27 @@ where
 
 impl<T> Default for RouteAgentDispatcher<T>
 where
-    for<'de> T: AgentState<'de>,
+    T: RouteState
 {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<T: for<'de> AgentState<'de>> Debug for RouteAgentDispatcher<T> {
+impl<T: RouteState> Debug for RouteAgentDispatcher<T> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
         f.debug_tuple("RouteAgentDispatcher").finish()
     }
 }
 
-impl<T: for<'de> AgentState<'de>> Deref for RouteAgentDispatcher<T> {
+impl<T: RouteState> Deref for RouteAgentDispatcher<T> {
     type Target = Dispatcher<RouteAgent<T>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
-impl<T: for<'de> AgentState<'de>> DerefMut for RouteAgentDispatcher<T> {
+impl<T: RouteState> DerefMut for RouteAgentDispatcher<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -20,9 +20,7 @@ pub use bridge::RouteAgentBridge;
 mod dispatcher;
 pub use dispatcher::RouteAgentDispatcher;
 
-/// Any state that can be used in the router agent must meet the criteria of this trait.
-pub trait AgentState<'de>: RouteState + Serialize + Deserialize<'de> + Debug {}
-impl<'de, T> AgentState<'de> for T where T: RouteState + Serialize + Deserialize<'de> + Debug {}
+
 
 /// Internal Message used for the RouteAgent.
 #[derive(Debug)]
@@ -61,7 +59,7 @@ pub enum RouteRequest<T = ()> {
 /// each other and associated components may not work as intended.
 pub struct RouteAgent<T = ()>
 where
-    for<'de> T: AgentState<'de>,
+    T: RouteState,
 {
     // In order to have the AgentLink<Self> below, apparently T must be constrained like this.
     // Unfortunately, this means that everything related to an agent requires this constraint.
@@ -74,7 +72,7 @@ where
     subscribers: HashSet<HandlerId>,
 }
 
-impl<T: for<'de> AgentState<'de>> Debug for RouteAgent<T> {
+impl<T: RouteState> Debug for RouteAgent<T> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
         f.debug_struct("RouteAgent")
             .field("link", &"-")
@@ -86,7 +84,7 @@ impl<T: for<'de> AgentState<'de>> Debug for RouteAgent<T> {
 
 impl<T> Agent for RouteAgent<T>
 where
-    for<'de> T: AgentState<'de>,
+    T: RouteState,
 {
     type Input = RouteRequest<T>;
     type Message = Msg<T>;

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -15,7 +15,7 @@ use crate::RouterState;
 // TODO This should also be PartialEq and Clone. Its blocked on Children not supporting that.
 /// Properties for `RouterButton` and `RouterLink`.
 #[derive(Properties, Default, Debug)]
-pub struct Props<T: for<'de> RouterState<'de>> {
+pub struct Props<T: RouterState> {
     /// The route that will be set when the component is clicked.
     pub link: String,
     /// The state to set when changing the route.

--- a/src/components/router_button.rs
+++ b/src/components/router_button.rs
@@ -11,13 +11,13 @@ use yew::virtual_dom::VNode;
 
 /// Changes the route when clicked.
 #[derive(Debug)]
-pub struct RouterButton<T: for<'de> RouterState<'de> = ()> {
+pub struct RouterButton<T: RouterState = ()> {
     link: ComponentLink<Self>,
     router: RouteAgentDispatcher<T>,
     props: Props<T>,
 }
 
-impl<T: for<'de> RouterState<'de>> Component for RouterButton<T> {
+impl<T: RouterState> Component for RouterButton<T> {
     type Message = Msg;
     type Properties = Props<T>;
 

--- a/src/components/router_link.rs
+++ b/src/components/router_link.rs
@@ -17,13 +17,13 @@ pub type RouterLink<T> = RouterAnchor<T>;
 
 /// An anchor tag Component that when clicked, will navigate to the provided route.
 #[derive(Debug)]
-pub struct RouterAnchor<T: for<'de> RouterState<'de> = ()> {
+pub struct RouterAnchor<T: RouterState = ()> {
     link: ComponentLink<Self>,
     router: RouteAgentDispatcher<T>,
     props: Props<T>,
 }
 
-impl<T: for<'de> RouterState<'de>> Component for RouterAnchor<T> {
+impl<T: RouterState> Component for RouterAnchor<T> {
     type Message = Msg;
     type Properties = Props<T>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,8 +100,6 @@ pub mod prelude {
     pub use crate::switch::Switch;
     pub use yew_router_macro::Switch;
     // State restrictions
-    #[cfg(feature = "agent")]
-    pub use crate::agent::AgentState;
     pub use crate::route::RouteState;
     #[cfg(feature = "router")]
     pub use crate::router::RouterState;
@@ -113,8 +111,6 @@ pub mod matcher;
 
 pub use matcher::Captures;
 
-#[cfg(feature = "agent")]
-pub use crate::agent::AgentState;
 pub use crate::route::RouteState;
 #[cfg(feature = "router")]
 pub use crate::router::RouterState;

--- a/src/route.rs
+++ b/src/route.rs
@@ -2,13 +2,9 @@
 use crate::service::RouteService;
 use serde::{Deserialize, Serialize};
 use std::{fmt, ops::Deref};
-use stdweb::{unstable::TryFrom, JsSerialize, Value};
+use stdweb::{unstable::TryFrom, Value};
 use std::fmt::Debug;
 use serde::de::DeserializeOwned;
-
-///// Any state that can be stored by the History API must meet the criteria of this trait.
-//pub trait RouteState: Clone + Default + TryFrom<Value> + 'static {}
-//impl<T> RouteState for T where T: Clone + Default + TryFrom<Value> + 'static {}
 
 /// Any state that can be used in the router agent must meet the criteria of this trait.
 pub trait RouteState: Serialize + DeserializeOwned + Debug + Clone + Default + TryFrom<Value> + 'static {}
@@ -54,7 +50,7 @@ impl<T> Route<T> {
 
 impl<T> fmt::Display for Route<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.route.fmt(f)
+        std::fmt::Display::fmt(&self.route, f)
     }
 }
 

--- a/src/route.rs
+++ b/src/route.rs
@@ -3,10 +3,16 @@ use crate::service::RouteService;
 use serde::{Deserialize, Serialize};
 use std::{fmt, ops::Deref};
 use stdweb::{unstable::TryFrom, JsSerialize, Value};
+use std::fmt::Debug;
+use serde::de::DeserializeOwned;
 
-/// Any state that can be stored by the History API must meet the criteria of this trait.
-pub trait RouteState: Clone + Default + JsSerialize + TryFrom<Value> + 'static {}
-impl<T> RouteState for T where T: Clone + Default + JsSerialize + TryFrom<Value> + 'static {}
+///// Any state that can be stored by the History API must meet the criteria of this trait.
+//pub trait RouteState: Clone + Default + TryFrom<Value> + 'static {}
+//impl<T> RouteState for T where T: Clone + Default + TryFrom<Value> + 'static {}
+
+/// Any state that can be used in the router agent must meet the criteria of this trait.
+pub trait RouteState: Serialize + DeserializeOwned + Debug + Clone + Default + TryFrom<Value> + 'static {}
+impl<T> RouteState for T where T: Serialize + DeserializeOwned + Debug + Clone + Default + TryFrom<Value> + 'static {}
 
 /// The representation of a route, segmented into different sections for easy access.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
closes https://github.com/yewstack/yew_router/issues/185

`JsSerialize` no longer must be implemented on the type parameter of  `Route`.