### PR TITLE
Add a feature gate for service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,14 @@ unit_alias = []
 router = ["agent"]
 components = ["agent" ]
 agent = ["service"]
-service = ["stdweb"]
+service = ["stdweb", "yew"]
 
 
 [dependencies]
 log = "0.4.8"
-serde = "1.0.103"
-serde_derive = "1.0.103"
+serde = {version = "1.0.103", features = ["derive"]}
 #yew = "0.10.0"
-yew = {git = "https://github.com/yewstack/yew", branch = "master"}
+yew = {git = "https://github.com/yewstack/yew", branch = "master", optional = true}
 stdweb = {version = "0.4.20", optional = true}
 
 yew-router-route-parser = {path = "crates/yew_router_route_parser", version = "0.8.0"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ unit_alias = []
 
 router = ["agent"]
 components = ["agent" ]
-agent = []
+agent = ["service"]
+service = ["stdweb"]
 
 
 [dependencies]
@@ -28,7 +29,7 @@ serde = "1.0.103"
 serde_derive = "1.0.103"
 #yew = "0.10.0"
 yew = {git = "https://github.com/yewstack/yew", branch = "master"}
-stdweb = "0.4.20"
+stdweb = {version = "0.4.20", optional = true}
 
 yew-router-route-parser = {path = "crates/yew_router_route_parser", version = "0.8.0"}
 yew-router-macro = {path = "crates/yew_router_macro", version = "0.8.0"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,15 @@ repository = "https://github.com/yewstack/yew_router"
 [features]
 default = ["core", "unit_alias"]
 
-core = ["router", "components"]
+core = ["router", "components"] # Most everything
+
+# TODO remove this
 unit_alias = []
 
-router = ["agent"]
-components = ["agent" ]
-agent = ["service"]
-service = ["stdweb", "yew"]
+router = ["agent"] # The Router component
+components = ["agent" ] # The button and anchor
+agent = ["service"] # The RouteAgent
+service = ["stdweb", "yew"] # The RouteService
 
 
 [dependencies]

--- a/crates/yew_router_macro/src/switch/enum_impl.rs
+++ b/crates/yew_router_macro/src/switch/enum_impl.rs
@@ -33,7 +33,7 @@ pub fn generate_enum_impl(
     let token_stream = quote! {
         #impl_line
         {
-            fn from_route_part<__T: ::yew_router::route::RouteState>(route: ::yew_router::route::Route<__T>) -> (::std::option::Option<Self>, ::std::option::Option<__T>) {
+            fn from_route_part<__T>(route: ::yew_router::route::Route<__T>) -> (::std::option::Option<Self>, ::std::option::Option<__T>) {
                 let mut state = route.state;
                 let route_string = route.route;
                 #(#variant_matchers)*

--- a/crates/yew_router_macro/src/switch/struct_impl.rs
+++ b/crates/yew_router_macro/src/switch/struct_impl.rs
@@ -24,7 +24,7 @@ pub fn generate_struct_impl(item: SwitchItem, generics: Generics) -> TokenStream
     let token_stream = quote! {
         #impl_line
         {
-            fn from_route_part<__T: ::yew_router::route::RouteState>(route: ::yew_router::route::Route<__T>) -> (::std::option::Option<Self>, ::std::option::Option<__T>) {
+            fn from_route_part<__T>(route: ::yew_router::route::Route<__T>) -> (::std::option::Option<Self>, ::std::option::Option<__T>) {
 
                 #matcher
                 let mut state = route.state;

--- a/examples/minimal/Cargo.toml
+++ b/examples/minimal/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 #yew = "0.10.0"
 yew = {git = "https://github.com/yewstack/yew", branch = "master"}
-yew-router = {path = "../../", default-features=false}
+yew-router = {path = "../../", default-features=false, features = ["service"]}
 web_logger = "0.1"
 log = "0.4.8"
 wee_alloc = "0.4.5"

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -1,7 +1,7 @@
 # Minimal Example
 
-This example shows how to use this library without any of the features turned on.
-Without any features, you lack the `Router` component and `RouteAgent` and its associated bridges and dispatchers.
+This example shows how to use this library with only the "service" feature turned on.
+Without most of the features, you lack the `Router` component and `RouteAgent` and its associated bridges and dispatchers.
 This means that you must use the `RouteService` to interface with the browser to handle route changes.
 
 Removing the `Router` component means that you have to deal with the `RouteService` directly and propagate change route messages up to the component that contains the `RouteService`.

--- a/examples/router_component/src/main.rs
+++ b/examples/router_component/src/main.rs
@@ -13,7 +13,7 @@ use crate::{
     c_component::CModel,
 };
 use yew::virtual_dom::VNode;
-use yew_router::switch::AllowMissing;
+use yew_router::switch::{AllowMissing, Permissive};
 
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
@@ -62,12 +62,12 @@ impl Component for Model {
                                 },
                                 AppRoute::C => html!{<CModel />},
                                 AppRoute::E(string) => html!{format!("hello {}", string)},
-                                AppRoute::PageNotFound(None) => html!{"Page not found"},
-                                AppRoute::PageNotFound(Some(missed_route)) => html!{format!("Page '{}' not found", missed_route)}
+                                AppRoute::PageNotFound(Permissive(None)) => html!{"Page not found"},
+                                AppRoute::PageNotFound(Permissive(Some(missed_route))) => html!{format!("Page '{}' not found", missed_route)}
                             }
                         })
                         redirect = Router::redirect(|route: Route| {
-                            AppRoute::PageNotFound(Some(route.route))
+                            AppRoute::PageNotFound(Permissive(Some(route.route)))
                         })
                     />
                 </div>
@@ -87,7 +87,7 @@ pub enum AppRoute {
     #[to = "/e/{string}"]
     E(String),
     #[to = "/page-not-found"]
-    PageNotFound(Option<String>),
+    PageNotFound(Permissive<String>),
 }
 
 #[derive(Debug, Switch, PartialEq, Clone, Copy)]

--- a/examples/switch/Cargo.toml
+++ b/examples/switch/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yew-router = {path = "../../"}
+yew-router = {path = "../../", default-features=false}

--- a/examples/switch/src/main.rs
+++ b/examples/switch/src/main.rs
@@ -1,35 +1,36 @@
 use yew_router::{route::Route, Switch};
+use yew_router::switch::Permissive;
 
 fn main() {
-    let route = Route::<()>::from("/some/route");
+    let route = Route::new_no_state("/some/route");
     let app_route = AppRoute::switch(route);
     dbg!(app_route);
 
-    let route = Route::<()>::from("/some/thing/other");
+    let route = Route::new_no_state("/some/thing/other");
     let app_route = AppRoute::switch(route);
     dbg!(app_route);
 
-    let route = Route::<()>::from("/another/other");
+    let route = Route::new_no_state("/another/other");
     let app_route = AppRoute::switch(route);
     dbg!(app_route);
 
-    let route = Route::<()>::from("/inner/left");
+    let route = Route::new_no_state("/inner/left");
     let app_route = AppRoute::switch(route);
     dbg!(app_route);
 
-    let route = Route::<()>::from("/yeet"); // should not match
+    let route = Route::new_no_state("/yeet"); // should not match
     let app_route = AppRoute::switch(route);
     dbg!(app_route);
 
-    let route = Route::<()>::from("/single/32");
+    let route = Route::new_no_state("/single/32");
     let app_route = AppRoute::switch(route);
     dbg!(app_route);
 
-    let route = Route::<()>::from("/othersingle/472");
+    let route = Route::new_no_state("/othersingle/472");
     let app_route = AppRoute::switch(route);
     dbg!(app_route);
 
-    let route = Route::<()>::from("/option/test");
+    let route = Route::new_no_state("/option/test");
     let app_route = AppRoute::switch(route);
     dbg!(app_route);
 
@@ -69,12 +70,12 @@ pub enum AppRoute {
     Single(Single),
     #[rest]
     OtherSingle(OtherSingle),
-    /// Because this is an option, the inner item doesn't have to match.
+    /// Because this is permissive, the inner item doesn't have to match.
     #[to = "/option/{}"]
-    Optional(Option<String>),
-    /// Because this is an option, a corresponding capture group doesn't need to exist
+    Optional(Permissive<String>),
+    /// Because this is permissive, a corresponding capture group doesn't need to exist
     #[to = "/missing/capture"]
-    MissingCapture(Option<String>),
+    MissingCapture(Permissive<String>),
 }
 
 #[derive(Switch, Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ pub mod components;
 #[cfg(feature = "router")]
 pub mod router;
 
+/// TODO remove this
 /// Contains aliases and functions for working with this library using a state of type  `()`.
 #[cfg(feature = "unit_alias")]
 pub mod unit_state {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,8 @@ pub use yew_router_route_parser;
 
 #[macro_use]
 mod alias;
+
+#[cfg(feature = "service")]
 pub mod service;
 
 #[cfg(feature = "agent")]
@@ -83,26 +85,32 @@ pub mod unit_state {
 pub mod prelude {
     pub use super::matcher::Captures;
 
+    #[cfg(feature = "service")]
+    pub use crate::service::RouteService;
+    #[cfg(feature = "service")]
+    pub use crate::route::RouteState;
+
     #[cfg(feature = "agent")]
     pub use crate::agent::RouteAgent;
     #[cfg(feature = "agent")]
     pub use crate::agent::RouteAgentBridge;
     #[cfg(feature = "agent")]
     pub use crate::agent::RouteAgentDispatcher;
+
     #[cfg(feature = "components")]
     pub use crate::components::RouterAnchor;
     #[cfg(feature = "components")]
     pub use crate::components::RouterButton;
+
     #[cfg(feature = "router")]
     pub use crate::router::Router;
-    pub use crate::{route::Route, service::RouteService};
 
-    pub use crate::switch::{Switch, Routable};
-    pub use yew_router_macro::Switch;
-    // State restrictions
-    pub use crate::route::RouteState;
     #[cfg(feature = "router")]
     pub use crate::router::RouterState;
+
+    pub use crate::route::Route;
+    pub use crate::switch::{Switch, Routable};
+    pub use yew_router_macro::Switch;
 }
 
 pub use alias::*;
@@ -111,6 +119,7 @@ pub mod matcher;
 
 pub use matcher::Captures;
 
+#[cfg(feature = "service")]
 pub use crate::route::RouteState;
 #[cfg(feature = "router")]
 pub use crate::router::RouterState;

--- a/src/route.rs
+++ b/src/route.rs
@@ -47,7 +47,7 @@ impl Route<()> {
     pub fn new_no_state<T: AsRef<str>>(route: T) -> Self {
         Route {
             route: route.as_ref().to_string(),
-            state: None,
+            state: (),
         }
     }
 }
@@ -57,7 +57,7 @@ impl <T: Default> Route<T> {
     pub fn new_default_state<U: AsRef<str>>(route: U) -> Self {
         Route {
             route: route.as_ref().to_string(),
-            state: Some(T::default()),
+            state: T::default(),
         }
     }
 }
@@ -68,15 +68,15 @@ impl<T> fmt::Display for Route<T> {
     }
 }
 
-// This is getting removed anyway
-impl<T: Default> From<&str> for Route<T> {
-    fn from(string: &str) -> Route<T> {
-        Route {
-            route: string.to_string(),
-            state: T::default(),
-        }
-    }
-}
+//// This is getting removed anyway
+//impl<T: Default> From<&str> for Route<T> {
+//    fn from(string: &str) -> Route<T> {
+//        Route {
+//            route: string.to_string(),
+//            state: T::default(),
+//        }
+//    }
+//}
 
 impl<T> Deref for Route<T> {
     type Target = String;

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,13 +1,19 @@
 //! Wrapper around route url string, and associated history state.
+#[cfg(feature = "service")]
 use crate::service::RouteService;
-use serde::{Deserialize, Serialize};
-use std::{fmt, ops::Deref};
+#[cfg(feature = "service")]
 use stdweb::{unstable::TryFrom, Value};
-use std::fmt::Debug;
+#[cfg(feature = "service")]
 use serde::de::DeserializeOwned;
 
+use serde::{Deserialize, Serialize};
+use std::{fmt, ops::Deref};
+use std::fmt::Debug;
+
 /// Any state that can be used in the router agent must meet the criteria of this trait.
+#[cfg(feature = "service")]
 pub trait RouteState: Serialize + DeserializeOwned + Debug + Clone + Default + TryFrom<Value> + 'static {}
+#[cfg(feature = "service")]
 impl<T> RouteState for T where T: Serialize + DeserializeOwned + Debug + Clone + Default + TryFrom<Value> + 'static {}
 
 /// The representation of a route, segmented into different sections for easy access.
@@ -19,6 +25,8 @@ pub struct Route<T = ()> {
     pub state: Option<T>,
 }
 
+
+#[cfg(feature = "service")]
 /// Formats a path, query, and fragment into a string.
 ///
 /// # Note
@@ -32,6 +40,7 @@ pub(crate) fn format_route_string(path: &str, query: &str, fragment: &str) -> St
     )
 }
 
+#[cfg(feature = "service")]
 impl<T> Route<T> {
     /// Gets the current route from the route service.
     ///

--- a/src/route.rs
+++ b/src/route.rs
@@ -58,13 +58,23 @@ impl<T> Route<T> {
 }
 
 impl Route<()> {
-    /// Creates a new route out of a string.
+    /// Creates a new route with no state out of a string.
     ///
     /// This Route will have `()` for its state.
     pub fn new_no_state<T: AsRef<str>>(route: T) -> Self {
         Route {
             route: route.as_ref().to_string(),
             state: None,
+        }
+    }
+}
+
+impl <T: Default> Route<T> {
+    /// Creates a new route out of a string, setting the state to its default value.
+    pub fn new_default_state<U: AsRef<str>>(route: U) -> Self {
+        Route {
+            route: route.as_ref().to_string(),
+            state: Some(T::default()),
         }
     }
 }

--- a/src/route.rs
+++ b/src/route.rs
@@ -22,7 +22,7 @@ pub struct Route<T = ()> {
     /// The route string
     pub route: String,
     /// The state stored in the history api
-    pub state: Option<T>,
+    pub state: Option<T>, // TODO eventually make this just `T`
 }
 
 
@@ -57,18 +57,21 @@ impl<T> Route<T> {
     }
 }
 
-impl<T> fmt::Display for Route<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        std::fmt::Display::fmt(&self.route, f)
+impl Route<()> {
+    /// Creates a new route out of a string.
+    ///
+    /// This Route will have `()` for its state.
+    pub fn new_no_state<T: AsRef<str>>(route: T) -> Self {
+        Route {
+            route: route.as_ref().to_string(),
+            state: None,
+        }
     }
 }
 
-impl<T> From<&str> for Route<T> {
-    fn from(string: &str) -> Route<T> {
-        Route {
-            route: string.to_string(),
-            state: None,
-        }
+impl<T> fmt::Display for Route<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        std::fmt::Display::fmt(&self.route, f)
     }
 }
 

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,7 +1,5 @@
 //! Wrapper around route url string, and associated history state.
 #[cfg(feature = "service")]
-use crate::service::RouteService;
-#[cfg(feature = "service")]
 use stdweb::{unstable::TryFrom, Value};
 #[cfg(feature = "service")]
 use serde::de::DeserializeOwned;
@@ -25,20 +23,6 @@ pub struct Route<T = ()> {
     pub state: T,
 }
 
-
-#[cfg(feature = "service")]
-/// Formats a path, query, and fragment into a string.
-///
-/// # Note
-/// This expects that all three already have their expected separators (?, #, etc)
-pub(crate) fn format_route_string(path: &str, query: &str, fragment: &str) -> String {
-    format!(
-        "{path}{query}{fragment}",
-        path = path,
-        query = query,
-        fragment = fragment
-    )
-}
 
 impl Route<()> {
     /// Creates a new route with no state out of a string.
@@ -67,16 +51,6 @@ impl<T> fmt::Display for Route<T> {
         std::fmt::Display::fmt(&self.route, f)
     }
 }
-
-//// This is getting removed anyway
-//impl<T: Default> From<&str> for Route<T> {
-//    fn from(string: &str) -> Route<T> {
-//        Route {
-//            route: string.to_string(),
-//            state: T::default(),
-//        }
-//    }
-//}
 
 impl<T> Deref for Route<T> {
     type Target = String;

--- a/src/service.rs
+++ b/src/service.rs
@@ -49,7 +49,7 @@ impl<T> RouteService<T> {
         let path = location.pathname().unwrap();
         let query = location.search().unwrap();
         let fragment = location.hash().unwrap();
-        crate::route::format_route_string(&path, &query, &fragment)
+        format_route_string(&path, &query, &fragment)
     }
 
 
@@ -143,6 +143,21 @@ where
         }
     }
 }
+
+
+/// Formats a path, query, and fragment into a string.
+///
+/// # Note
+/// This expects that all three already have their expected separators (?, #, etc)
+pub(crate) fn format_route_string(path: &str, query: &str, fragment: &str) -> String {
+    format!(
+        "{path}{query}{fragment}",
+        path = path,
+        query = query,
+        fragment = fragment
+    )
+}
+
 
 fn get_state(history: &History) -> Value {
     js!(

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -29,21 +29,21 @@ pub type Routable = Switch;
 /// }
 ///
 /// assert_eq!(
-///     TestEnum::switch(Route::<()>::from("/test/route")),
+///     TestEnum::switch(Route::new_no_state("/test/route")),
 ///     Some(TestEnum::TestRoute)
 /// );
 /// assert_eq!(
-///     TestEnum::switch(Route::<()>::from("/capture/string/lorem")),
+///     TestEnum::switch(Route::new_no_state("/capture/string/lorem")),
 ///     Some(TestEnum::CaptureString {
 ///         path: "lorem".to_string()
 ///     })
 /// );
 /// assert_eq!(
-///     TestEnum::switch(Route::<()>::from("/capture/number/22")),
+///     TestEnum::switch(Route::new_no_state("/capture/number/22")),
 ///     Some(TestEnum::CaptureNumber { num: 22 })
 /// );
 /// assert_eq!(
-///     TestEnum::switch(Route::<()>::from("/capture/unnamed/lorem")),
+///     TestEnum::switch(Route::new_no_state("/capture/unnamed/lorem")),
 ///     Some(TestEnum::CaptureUnnamed("lorem".to_string()))
 /// );
 /// ```
@@ -238,10 +238,10 @@ mod test {
 
     #[test]
     fn can_get_option_string_from_empty_str() {
-        let (s, _state): (Option<Option<String>>, Option<()>) = Option::from_route_part(Route {
+        let (s, _state): (Option<Permissive<String>>, Option<()>) = Permissive::from_route_part(Route {
             route: "".to_string(),
             state: None,
         });
-        assert_eq!(s, Some(Some("".to_string())))
+        assert_eq!(s, Some(Permissive(Some("".to_string()))))
     }
 }

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -180,6 +180,21 @@ impl<SW: Switch, T: Default> From<SW> for Route<T> {
     }
 }
 
+
+impl<T: std::str::FromStr + std::fmt::Display> Switch for T {
+    fn from_route_part<U>(part: String, state: Option<U>) -> (Option<Self>, Option<U>) {
+        (
+            ::std::str::FromStr::from_str(&part).ok(),
+            state
+        )
+    }
+
+    fn build_route_section<U>(self, route: &mut String) -> Option<U> {
+        write!(route, "{}", self).expect("Writing to string should never fail.");
+        None
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -224,6 +239,6 @@ mod test {
             "".to_string(),
             Some(()),
         );
-        assert_eq!(s, Some(Some("".to_string())))
+        assert_eq!(s, Some(Permissive(Some("".to_string()))))
     }
 }

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -164,6 +164,7 @@ impl<U: Switch + std::fmt::Debug> Switch for AllowMissing<U> {
     }
 }
 
+// TODO explore if adding a crate-defined trait here would satisfy coherence rules for option. Then add that trait to all items previously in the macro.
 impl<T: std::str::FromStr + std::fmt::Display> Switch for T {
     fn from_route_part<U>(part: Route<U>) -> (Option<Self>, Option<U>) {
         (

--- a/tests/macro_test/src/lib.rs
+++ b/tests/macro_test/src/lib.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests {
     use yew_router::{prelude::Route, Switch};
+    use yew_router::switch::Permissive;
 
     #[test]
     fn single_enum_variant() {
@@ -9,7 +10,7 @@ mod tests {
             #[to = "/variant"]
             Variant,
         }
-        let route: Route = Route::from("/variant");
+        let route = Route::new_no_state("/variant");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant)
     }
@@ -21,12 +22,12 @@ mod tests {
             #[to = "/variant"]
             Variant(String),
         }
-        let route: Route = Route::from("/variant");
+        let route = Route::new_no_state("/variant");
         assert!(
             Test::switch(route).is_none(),
             "there should not be a way to ever create this variant."
         );
-        let route: Route = Route::from("/variant/some/stuff");
+        let route = Route::new_no_state("/variant/some/stuff");
         assert!(
             Test::switch(route).is_none(),
             "there should not be a way to ever create this variant."
@@ -40,7 +41,7 @@ mod tests {
             #[to = "/variant/{item}"]
             Variant { item: String },
         }
-        let route: Route = Route::from("/variant/thing");
+        let route = Route::new_no_state("/variant/thing");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(
             switched,
@@ -57,7 +58,7 @@ mod tests {
             #[to = "/variant/{item}"]
             Variant(String),
         }
-        let route: Route = Route::from("/variant/thing");
+        let route = Route::new_no_state("/variant/thing");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant("thing".to_string()))
     }
@@ -69,7 +70,7 @@ mod tests {
             #[to = "/variant/{}/{}"] // For unnamed variants, the names don't matter at all
             Variant(String, String),
         }
-        let route: Route = Route::from("/variant/thing/other");
+        let route = Route::new_no_state("/variant/thing/other");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(
             switched,
@@ -84,7 +85,7 @@ mod tests {
             #[to = "/variant/{item1}/{item2}"]
             Variant { item1: String, item2: String },
         }
-        let route: Route = Route::from("/variant/thing/other");
+        let route = Route::new_no_state("/variant/thing/other");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(
             switched,
@@ -102,7 +103,7 @@ mod tests {
             #[to = "/variant{item}"]
             Variant { item: String },
         }
-        let route: Route = Route::from("/variantthing");
+        let route = Route::new_no_state("/variantthing");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(
             switched,
@@ -119,7 +120,7 @@ mod tests {
             #[to = "/variant{item}stuff"]
             Variant { item: String },
         }
-        let route: Route = Route::from("/variantthingstuff");
+        let route = Route::new_no_state("/variantthingstuff");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(
             switched,
@@ -136,7 +137,7 @@ mod tests {
             #[to = "/variant!"]
             Variant,
         }
-        let route: Route = Route::from("/variant/");
+        let route = Route::new_no_state("/variant/");
         assert!(Test::switch(route).is_none());
     }
 
@@ -149,7 +150,7 @@ mod tests {
             #[to = "/variant/stuff"]
             Variant2,
         }
-        let route: Route = Route::from("/variant/stuff");
+        let route = Route::new_no_state("/variant/stuff");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(
             switched,
@@ -167,7 +168,7 @@ mod tests {
             #[to = "/variant/stuff"]
             Variant2,
         }
-        let route: Route = Route::from("/variant/stuff");
+        let route = Route::new_no_state("/variant/stuff");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(
             switched,
@@ -183,7 +184,7 @@ mod tests {
             #[to = "/variant/{item}"]
             Variant(usize),
         }
-        let route: Route = Route::from("/variant/42");
+        let route = Route::new_no_state("/variant/42");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant(42))
     }
@@ -195,7 +196,7 @@ mod tests {
             #[to = "/variant/{item}"]
             Variant(usize),
         }
-        let route: Route = Route::from("/variant/-42");
+        let route = Route::new_no_state("/variant/-42");
         assert!(Test::switch(route).is_none());
     }
 
@@ -206,21 +207,21 @@ mod tests {
             #[to = "/variant/{item}"]
             Variant(isize),
         }
-        let route: Route = Route::from("/variant/-42");
+        let route = Route::new_no_state("/variant/-42");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant(-42))
     }
 
     #[test]
-    fn single_enum_variant_missing_cap_produces_option_none() {
+    fn single_enum_variant_missing_cap_produces_permissive_option_none() {
         #[derive(Debug, Switch, PartialEq, Clone)]
         pub enum Test {
             #[to = "/variant"]
-            Variant(Option<String>),
+            Variant(Permissive<String>),
         }
-        let route: Route = Route::from("/variant");
+        let route = Route::new_no_state("/variant");
         let switched = Test::switch(route).expect("should produce item");
-        assert_eq!(switched, Test::Variant(None))
+        assert_eq!(switched, Test::Variant(Permissive(None)))
     }
 
     // TODO allow missing is a little broken at the moment.
@@ -244,7 +245,7 @@ mod tests {
             #[to = "/"]
             Variant,
         }
-        let route: Route = Route::from("/");
+        let route = Route::new_no_state("/");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant)
     }
@@ -256,7 +257,7 @@ mod tests {
             #[to = "{cap}"]
             Variant(String),
         }
-        let route: Route = Route::from("hello");
+        let route = Route::new_no_state("hello");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant("hello".to_string()))
     }
@@ -268,7 +269,7 @@ mod tests {
             #[to = "{}"]
             Variant(String),
         }
-        let route: Route = Route::from("hello");
+        let route = Route::new_no_state("hello");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant("hello".to_string()))
     }
@@ -280,7 +281,7 @@ mod tests {
             #[to = "{2:cap}"]
             Variant(String),
         }
-        let route: Route = Route::from("hello/there");
+        let route = Route::new_no_state("hello/there");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant("hello/there".to_string()))
     }
@@ -292,7 +293,7 @@ mod tests {
             #[to = "{2}"]
             Variant(String),
         }
-        let route: Route = Route::from("hello/there");
+        let route = Route::new_no_state("hello/there");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant("hello/there".to_string()))
     }
@@ -304,7 +305,7 @@ mod tests {
             #[to = "{*:cap}"]
             Variant(String),
         }
-        let route: Route = Route::from("hello/there");
+        let route = Route::new_no_state("hello/there");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant("hello/there".to_string()))
     }
@@ -316,7 +317,7 @@ mod tests {
             #[to = "{*}"]
             Variant(String),
         }
-        let route: Route = Route::from("hello/there");
+        let route = Route::new_no_state("hello/there");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant("hello/there".to_string()))
     }
@@ -328,7 +329,7 @@ mod tests {
             #[to = "?query={hello}"]
             Variant(String),
         }
-        let route: Route = Route::from("?query=lorem");
+        let route = Route::new_no_state("?query=lorem");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant("lorem".to_string()))
     }
@@ -340,7 +341,7 @@ mod tests {
             #[to = "?query={}"]
             Variant(String),
         }
-        let route: Route = Route::from("?query=lorem");
+        let route = Route::new_no_state("?query=lorem");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant("lorem".to_string()))
     }
@@ -352,7 +353,7 @@ mod tests {
             #[to = "#fragment"]
             Variant,
         }
-        let route: Route = Route::from("#fragment");
+        let route = Route::new_no_state("#fragment");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant)
     }
@@ -364,7 +365,7 @@ mod tests {
             #[to = "#{cap}ipsum{cap}"]
             Variant(String, String),
         }
-        let route: Route = Route::from("#loremipsumdolor");
+        let route = Route::new_no_state("#loremipsumdolor");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(
             switched,
@@ -379,7 +380,7 @@ mod tests {
             #[to = "#{}ipsum{}"]
             Variant(String, String),
         }
-        let route: Route = Route::from("#loremipsumdolor");
+        let route = Route::new_no_state("#loremipsumdolor");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(
             switched,
@@ -394,7 +395,7 @@ mod tests {
             #[to = "/escape!!"]
             Variant,
         }
-        let route: Route = Route::from("/escape!");
+        let route = Route::new_no_state("/escape!");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant)
     }
@@ -406,7 +407,7 @@ mod tests {
             #[to = "/escape{{}}a"]
             Variant,
         }
-        let route: Route = Route::from("/escape{}a");
+        let route = Route::new_no_state("/escape{}a");
         let switched = Test::switch(route).expect("should produce item");
         assert_eq!(switched, Test::Variant)
     }
@@ -421,7 +422,7 @@ mod tests {
                 #[to = "#/lorem"]
                 Variant,
             }
-            let route: Route = Route::from("#/lorem");
+            let route = Route::new_no_state("#/lorem");
             Test::switch(route).expect("should produce item");
         }
 
@@ -432,7 +433,7 @@ mod tests {
                 #[to = "#/lorem=ipsum"]
                 Variant,
             }
-            let route: Route = Route::from("#/lorem=ipsum");
+            let route = Route::new_no_state("#/lorem=ipsum");
             Test::switch(route).expect("should produce item");
         }
 
@@ -443,7 +444,7 @@ mod tests {
                 #[to = "#/lorem={ipsum}"]
                 Variant { ipsum: String },
             }
-            let route: Route = Route::from("#/lorem=dolor");
+            let route = Route::new_no_state("#/lorem=dolor");
             let switched = Test::switch(route).expect("should produce item");
             assert_eq!(
                 switched,


### PR DESCRIPTION
Fixes https://github.com/yewstack/yew_router/issues/199

Allows specifying if the `RouterService` is compiled - which stdweb support is contingent upon.

This should allow the library to be used outside of a web environment as it breaks the dependency on anything relying on emscripten.