### PR TITLE
Relax capture rules in Fragment sections in route syntax parser

### DIFF
--- a/crates/yew_router_route_parser/src/core.rs
+++ b/crates/yew_router_route_parser/src/core.rs
@@ -184,14 +184,6 @@ pub fn capture<'a>(
     map(capture_impl(field_naming_scheme), RouteParserToken::Capture)
 }
 
-pub fn capture_single<'a>(
-    field_naming_scheme: FieldNamingScheme,
-) -> impl Fn(&'a str) -> IResult<&'a str, RouteParserToken<'a>, ParseError> {
-    map(
-        capture_single_impl(field_naming_scheme),
-        RouteParserToken::Capture,
-    )
-}
 
 fn capture_single_impl<'a>(
     field_naming_scheme: FieldNamingScheme,

--- a/crates/yew_router_route_parser/src/parser.rs
+++ b/crates/yew_router_route_parser/src/parser.rs
@@ -1,7 +1,7 @@
 //! Parser that consumes a string and produces the first representation of the matcher.
 use crate::{
     core::{
-        capture, capture_single, exact, fragment_exact, get_and, get_end, get_hash, get_question,
+        capture, exact, fragment_exact, get_and, get_end, get_hash, get_question,
         get_slash, nothing, query,
     },
     error::{get_reason, ParseError, ParserErrorReason, PrettyParseError},

--- a/crates/yew_router_route_parser/src/parser.rs
+++ b/crates/yew_router_route_parser/src/parser.rs
@@ -1,8 +1,8 @@
 //! Parser that consumes a string and produces the first representation of the matcher.
 use crate::{
     core::{
-        capture, exact, fragment_exact, get_and, get_end, get_hash, get_question,
-        get_slash, nothing, query,
+        capture, exact, fragment_exact, get_and, get_end, get_hash, get_question, get_slash,
+        nothing, query,
     },
     error::{get_reason, ParseError, ParserErrorReason, PrettyParseError},
     FieldNamingScheme,
@@ -391,7 +391,7 @@ fn parse_impl<'a>(
                 alt((fragment_exact, capture(field_naming_scheme), get_end))(i)
             }
             RouteParserToken::Exact(_) => alt((capture(field_naming_scheme), get_end))(i),
-            RouteParserToken::Capture(_)=> alt((fragment_exact, get_end))(i),
+            RouteParserToken::Capture(_) => alt((fragment_exact, get_end))(i),
             _ => Err(nom::Err::Failure(ParseError {
                 reason: Some(ParserErrorReason::InvalidState),
                 expected: vec![],

--- a/crates/yew_router_route_parser/src/parser.rs
+++ b/crates/yew_router_route_parser/src/parser.rs
@@ -388,10 +388,10 @@ fn parse_impl<'a>(
         },
         ParserState::Fragment { prev_token } => match prev_token {
             RouteParserToken::FragmentBegin => {
-                alt((fragment_exact, capture_single(field_naming_scheme), get_end))(i)
+                alt((fragment_exact, capture(field_naming_scheme), get_end))(i)
             }
-            RouteParserToken::Exact(_) => alt((capture_single(field_naming_scheme), get_end))(i),
-            RouteParserToken::Capture(_) => alt((fragment_exact, get_end))(i),
+            RouteParserToken::Exact(_) => alt((capture(field_naming_scheme), get_end))(i),
+            RouteParserToken::Capture(_)=> alt((fragment_exact, get_end))(i),
             _ => Err(nom::Err::Failure(ParseError {
                 reason: Some(ParserErrorReason::InvalidState),
                 expected: vec![],

--- a/examples/minimal/src/main.rs
+++ b/examples/minimal/src/main.rs
@@ -73,7 +73,7 @@ impl Component for Model {
                     AppRoute::C => format!("/c"),
                 };
                 self.route_service.set_route(&route_string, ());
-                self.route = Route{
+                self.route = Route {
                     route: route_string,
                     state: (),
                 };

--- a/examples/router_component/src/a_component.rs
+++ b/examples/router_component/src/a_component.rs
@@ -1,8 +1,6 @@
-use crate::{c_component::CModel, ARoute};
+use crate::{c_component::CModel, ARoute, AppRoute};
 use yew::{prelude::*, virtual_dom::VNode, Properties};
-use yew_router::prelude::*;
-use yew_router::switch::AllowMissing;
-use crate::AppRoute;
+use yew_router::{prelude::*, switch::AllowMissing};
 
 pub struct AModel {
     props: Props,
@@ -35,25 +33,25 @@ impl Component for AModel {
 
     fn view(&self) -> VNode {
         html! {
-            <div>
-                { "I am the A component"}
-                <div>
-                    <RouterButton<AppRoute> route=AppRoute::A(AllowMissing(Some(ARoute)))>
-                        {"Go to a/c"}
-                    </RouterButton>
-//                    <RouterButton route="/a/d">
-//                        {"Go to a/d (route does not exist)"}
-//                    </RouterButton>
-                </div>
-                <div>
-                {
-                    match self.props.route {
-                        Some(_) => html!{<CModel/>},
-                        None => html!{}
-                    }
+                    <div>
+                        { "I am the A component"}
+                        <div>
+                            <RouterButton<AppRoute> route=AppRoute::A(AllowMissing(Some(ARoute)))>
+                                {"Go to a/c"}
+                            </RouterButton>
+        //                    <RouterButton route="/a/d">
+        //                        {"Go to a/d (route does not exist)"}
+        //                    </RouterButton>
+                        </div>
+                        <div>
+                        {
+                            match self.props.route {
+                                Some(_) => html!{<CModel/>},
+                                None => html!{}
+                            }
+                        }
+                        </div>
+                    </div>
                 }
-                </div>
-            </div>
-        }
     }
 }

--- a/examples/router_component/src/main.rs
+++ b/examples/router_component/src/main.rs
@@ -93,4 +93,3 @@ pub enum AppRoute {
 #[derive(Debug, Switch, PartialEq, Clone, Copy)]
 #[to = "/c"]
 pub struct ARoute;
-

--- a/examples/switch/src/main.rs
+++ b/examples/switch/src/main.rs
@@ -1,5 +1,4 @@
-use yew_router::{route::Route, Switch};
-use yew_router::switch::Permissive;
+use yew_router::{route::Route, switch::Permissive, Switch};
 
 fn main() {
     let route = Route::new_no_state("/some/route");

--- a/src/agent/bridge.rs
+++ b/src/agent/bridge.rs
@@ -1,5 +1,5 @@
 //! Bridge to RouteAgent.
-use crate::{agent::{RouteAgent}, route::Route, RouteState};
+use crate::{agent::RouteAgent, route::Route, RouteState};
 use std::{
     fmt::{Debug, Error as FmtError, Formatter},
     ops::{Deref, DerefMut},

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -1,11 +1,10 @@
 //! Dispatcher to RouteAgent.
-use crate::agent::{RouteAgent};
+use crate::{agent::RouteAgent, RouteState};
 use std::{
     fmt::{Debug, Error as FmtError, Formatter},
     ops::{Deref, DerefMut},
 };
 use yew::agent::{Dispatched, Dispatcher};
-use crate::RouteState;
 
 /// A wrapped dispatcher to the route agent.
 ///
@@ -16,7 +15,7 @@ where
 
 impl<STATE> RouteAgentDispatcher<STATE>
 where
-    STATE: RouteState
+    STATE: RouteState,
 {
     /// Creates a new bridge.
     pub fn new() -> Self {
@@ -27,7 +26,7 @@ where
 
 impl<STATE> Default for RouteAgentDispatcher<STATE>
 where
-    STATE: RouteState
+    STATE: RouteState,
 {
     fn default() -> Self {
         Self::new()

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -21,7 +21,6 @@ mod dispatcher;
 pub use dispatcher::RouteAgentDispatcher;
 
 
-
 /// Internal Message used for the RouteAgent.
 #[derive(Debug)]
 pub enum Msg<STATE> {
@@ -122,8 +121,7 @@ where
         match msg {
             RouteRequest::ReplaceRoute(route) => {
                 let route_string: String = route.to_string();
-                self.route_service
-                    .replace_route(&route_string, route.state);
+                self.route_service.replace_route(&route_string, route.state);
                 let route = self.route_service.get_route();
                 for sub in &self.subscribers {
                     self.link.respond(*sub, route.clone());
@@ -131,14 +129,12 @@ where
             }
             RouteRequest::ReplaceRouteNoBroadcast(route) => {
                 let route_string: String = route.to_string();
-                self.route_service
-                    .replace_route(&route_string, route.state);
+                self.route_service.replace_route(&route_string, route.state);
             }
             RouteRequest::ChangeRoute(route) => {
                 let route_string: String = route.to_string();
                 // set the route
-                self.route_service
-                    .set_route(&route_string, route.state);
+                self.route_service.set_route(&route_string, route.state);
                 // get the new route.
                 let route = self.route_service.get_route();
                 // broadcast it to all listening components
@@ -148,8 +144,7 @@ where
             }
             RouteRequest::ChangeRouteNoBroadcast(route) => {
                 let route_string: String = route.to_string();
-                self.route_service
-                    .set_route(&route_string, route.state);
+                self.route_service.set_route(&route_string, route.state);
             }
             RouteRequest::GetCurrentRoute => {
                 let route = self.route_service.get_route();

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -10,13 +10,16 @@ use yew::{Children, Properties};
 
 #[allow(deprecated)]
 pub use self::{router_button::RouterButton, router_link::RouterAnchor, router_link::RouterLink};
-use crate::{Switch};
+use crate::Switch;
 
 // TODO This should also be PartialEq and Clone. Its blocked on Children not supporting that.
 // TODO This should no longer take link & String, and instead take a route: SW implementing Switch
 /// Properties for `RouterButton` and `RouterLink`.
 #[derive(Properties, Default, Debug)]
-pub struct Props<SW> where SW: Switch {
+pub struct Props<SW>
+where
+    SW: Switch,
+{
     /// The Switched item representing the route.
     #[props(required)]
     pub route: SW,

--- a/src/components/router_button.rs
+++ b/src/components/router_button.rs
@@ -1,5 +1,9 @@
 //! A component wrapping a `<button>` tag that changes the route.
-use crate::{agent::{RouteAgentDispatcher, RouteRequest}, route::Route, Switch};
+use crate::{
+    agent::{RouteAgentDispatcher, RouteRequest},
+    route::Route,
+    Switch,
+};
 use yew::prelude::*;
 
 use super::{Msg, Props};
@@ -14,7 +18,7 @@ pub struct RouterButton<SW: Switch + Clone + 'static, STATE: RouterState = ()> {
     props: Props<SW>,
 }
 
-impl<SW: Switch +  Clone + 'static, STATE: RouterState> Component for RouterButton<SW, STATE> {
+impl<SW: Switch + Clone + 'static, STATE: RouterState> Component for RouterButton<SW, STATE> {
     type Message = Msg;
     type Properties = Props<SW>;
 

--- a/src/components/router_link.rs
+++ b/src/components/router_link.rs
@@ -1,5 +1,9 @@
 //! A component wrapping an `<a>` tag that changes the route.
-use crate::{agent::{RouteAgentDispatcher, RouteRequest}, route::Route, Switch};
+use crate::{
+    agent::{RouteAgentDispatcher, RouteRequest},
+    route::Route,
+    Switch,
+};
 use yew::prelude::*;
 
 use super::{Msg, Props};
@@ -50,25 +54,25 @@ impl<SW: Switch + Clone + 'static, STATE: RouterState> Component for RouterAncho
 
     fn view(&self) -> VNode {
         use stdweb::web::event::IEvent;
-//        let target: &str = &self.props.link;
+        //        let target: &str = &self.props.link;
         let cb = |x| self.link.callback(x);
 
         html! {
-            <a
-                class=self.props.classes.clone(),
-                onclick=cb(|event: ClickEvent | {
-                    event.prevent_default();
-                    Msg::Clicked
-                }),
-                disabled=self.props.disabled,
-//                href=target,
-            >
-                {
-                    #[allow(deprecated)]
-                    &self.props.text
+                    <a
+                        class=self.props.classes.clone(),
+                        onclick=cb(|event: ClickEvent | {
+                            event.prevent_default();
+                            Msg::Clicked
+                        }),
+                        disabled=self.props.disabled,
+        //                href=target,
+                    >
+                        {
+                            #[allow(deprecated)]
+                            &self.props.text
+                        }
+                        {self.props.children.iter().collect::<VNode>()}
+                    </a>
                 }
-                {self.props.children.iter().collect::<VNode>()}
-            </a>
-        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,9 +87,9 @@ pub mod prelude {
     pub use super::matcher::Captures;
 
     #[cfg(feature = "service")]
-    pub use crate::service::RouteService;
-    #[cfg(feature = "service")]
     pub use crate::route::RouteState;
+    #[cfg(feature = "service")]
+    pub use crate::service::RouteService;
 
     #[cfg(feature = "agent")]
     pub use crate::agent::RouteAgent;
@@ -109,8 +109,10 @@ pub mod prelude {
     #[cfg(feature = "router")]
     pub use crate::router::RouterState;
 
-    pub use crate::route::Route;
-    pub use crate::switch::{Switch, Routable};
+    pub use crate::{
+        route::Route,
+        switch::{Routable, Switch},
+    };
     pub use yew_router_macro::Switch;
 }
 

--- a/src/matcher/matcher_impl.rs
+++ b/src/matcher/matcher_impl.rs
@@ -69,7 +69,7 @@ fn matcher_impl<'a, 'b: 'a, CAP: CaptureCollection<'b>>(
     settings: MatcherSettings,
     mut i: &'a str,
 ) -> IResult<&'a str, CAP> {
-    trace!("Attempting to match path: {:?} using: {:?}", i, tokens);
+    trace!("Attempting to match route: {:?} using: {:?}", i, tokens);
 
     let mut iter = tokens.iter().peekable();
 

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,18 +1,26 @@
 //! Wrapper around route url string, and associated history state.
 #[cfg(feature = "service")]
-use stdweb::{unstable::TryFrom, Value};
-#[cfg(feature = "service")]
 use serde::de::DeserializeOwned;
+#[cfg(feature = "service")]
+use stdweb::{unstable::TryFrom, Value};
 
 use serde::{Deserialize, Serialize};
-use std::{fmt, ops::Deref};
-use std::fmt::Debug;
+use std::{
+    fmt::{self, Debug},
+    ops::Deref,
+};
 
 /// Any state that can be used in the router agent must meet the criteria of this trait.
 #[cfg(feature = "service")]
-pub trait RouteState: Serialize + DeserializeOwned + Debug + Clone + Default + TryFrom<Value> + 'static {}
+pub trait RouteState:
+    Serialize + DeserializeOwned + Debug + Clone + Default + TryFrom<Value> + 'static
+{
+}
 #[cfg(feature = "service")]
-impl<T> RouteState for T where T: Serialize + DeserializeOwned + Debug + Clone + Default + TryFrom<Value> + 'static {}
+impl<T> RouteState for T where
+    T: Serialize + DeserializeOwned + Debug + Clone + Default + TryFrom<Value> + 'static
+{
+}
 
 /// The representation of a route, segmented into different sections for easy access.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
@@ -36,7 +44,7 @@ impl Route<()> {
     }
 }
 
-impl <STATE: Default> Route<STATE> {
+impl<STATE: Default> Route<STATE> {
     /// Creates a new route out of a string, setting the state to its default value.
     pub fn new_default_state<T: AsRef<str>>(route: T) -> Self {
         Route {

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,6 +1,10 @@
 //! Router Component.
 
-use crate::{agent::{RouteAgentBridge, RouteRequest}, route::Route, Switch, RouteState};
+use crate::{
+    agent::{RouteAgentBridge, RouteRequest},
+    route::Route,
+    RouteState, Switch,
+};
 use std::{
     fmt::{self, Debug, Error as FmtError, Formatter},
     rc::Rc,
@@ -9,7 +13,7 @@ use yew::{html, virtual_dom::VNode, Component, ComponentLink, Html, Properties, 
 
 
 /// Any state that can be managed by the `Router` must meet the criteria of this trait.
-pub trait RouterState: RouteState + PartialEq  {}
+pub trait RouterState: RouteState + PartialEq {}
 impl<STATE> RouterState for STATE where STATE: RouteState + PartialEq {}
 
 /// Rendering control flow component.
@@ -130,7 +134,7 @@ pub trait RedirectFn<SW, STATE>: Fn(Route<STATE>) -> SW {}
 impl<T, SW, STATE> RedirectFn<SW, STATE> for T where T: Fn(Route<STATE>) -> SW {}
 /// Clonable Redirect function
 #[derive(Clone)]
-pub struct Redirect<SW: Switch + 'static, STATE:  RouterState>(
+pub struct Redirect<SW: Switch + 'static, STATE: RouterState>(
     pub(crate) Rc<dyn RedirectFn<SW, STATE>>,
 );
 impl<STATE: RouterState, SW: Switch + 'static> Redirect<SW, STATE> {

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,13 +1,17 @@
 //! Service that interfaces with the browser to handle routing.
 
-use stdweb::{web::{event::PopStateEvent, window, EventListenerHandle, History, IEventTarget, Location}, Value};
+use stdweb::{
+    web::{event::PopStateEvent, window, EventListenerHandle, History, IEventTarget, Location},
+    Value,
+};
 use yew::callback::Callback;
 
-use crate::route::{RouteState, Route};
+use crate::route::{Route, RouteState};
 use std::marker::PhantomData;
-use stdweb::unstable::TryFrom;
-use stdweb::unstable::TryInto;
-use stdweb::js;
+use stdweb::{
+    js,
+    unstable::{TryFrom, TryInto},
+};
 
 /// A service that facilitates manipulation of the browser's URL bar and responding to browser events
 /// when users press 'forward' or 'back'.
@@ -52,8 +56,6 @@ impl<T> RouteService<T> {
         format_route_string(&path, &query, &fragment)
     }
 
-
-
     /// Gets the path name of the current url.
     pub fn get_path(&self) -> String {
         self.location.pathname().unwrap()
@@ -93,7 +95,7 @@ where
             let route: String = Self::get_route_from_location(&location);
 
 
-            callback.emit(Route{route, state})
+            callback.emit(Route { route, state })
         }));
     }
 
@@ -139,7 +141,7 @@ where
             .unwrap_or_default();
         Route {
             route: route_string,
-            state
+            state,
         }
     }
 }
@@ -168,4 +170,3 @@ fn get_state(history: &History) -> Value {
 fn get_state_string(history: &History) -> Option<String> {
     get_state(history).try_into().ok()
 }
-

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -1,5 +1,5 @@
 //! Parses routes into enums or structs.
-use crate::{route::Route};
+use crate::route::Route;
 use std::fmt::Write;
 
 /// Alias to Switch.
@@ -83,7 +83,7 @@ pub struct LeadingSlash<T>(pub T);
 impl<U: Switch> Switch for LeadingSlash<U> {
     fn from_route_part<STATE>(part: String, state: Option<STATE>) -> (Option<Self>, Option<STATE>) {
         if part.starts_with('/') {
-            let part =  part[1..].to_string();
+            let part = part[1..].to_string();
             let (inner, state) = U::from_route_part(part, state);
             (inner.map(LeadingSlash), state)
         } else {
@@ -183,10 +183,7 @@ impl<SW: Switch, STATE: Default> From<SW> for Route<STATE> {
 
 impl<T: std::str::FromStr + std::fmt::Display> Switch for T {
     fn from_route_part<U>(part: String, state: Option<U>) -> (Option<Self>, Option<U>) {
-        (
-            ::std::str::FromStr::from_str(&part).ok(),
-            state
-        )
+        (::std::str::FromStr::from_str(&part).ok(), state)
     }
 
     fn build_route_section<U>(self, route: &mut String) -> Option<U> {
@@ -208,10 +205,7 @@ mod test {
 
     #[test]
     fn can_get_string_from_empty_str() {
-        let (s, _state) = String::from_route_part::<()>(
-            "".to_string(),
-            Some(()),
-        );
+        let (s, _state) = String::from_route_part::<()>("".to_string(), Some(()));
         assert_eq!(s, Some("".to_string()))
     }
 
@@ -235,10 +229,8 @@ mod test {
 
     #[test]
     fn can_get_option_string_from_empty_str() {
-        let (s, _state): (Option<Permissive<String>>, Option<()>) = Permissive::from_route_part(
-            "".to_string(),
-            Some(()),
-        );
+        let (s, _state): (Option<Permissive<String>>, Option<()>) =
+            Permissive::from_route_part("".to_string(), Some(()));
         assert_eq!(s, Some(Permissive(Some("".to_string()))))
     }
 }

--- a/tests/macro_test/src/lib.rs
+++ b/tests/macro_test/src/lib.rs
@@ -453,5 +453,42 @@ mod tests {
                 }
             )
         }
+
+        mod fragment {
+            use super::*;
+
+            #[derive(Switch, Debug, Clone, PartialEq)]
+            #[to = "{*:path}#{*:route}"]
+            pub struct FragmentAdapter<W: Switch> {
+                path: String,
+                route: W,
+            }
+
+            #[test]
+            fn fragment_is_ignored() {
+                #[derive(Debug, Switch, Clone, PartialEq)]
+                pub enum Test {
+                    #[to = "/hello"]
+                    Variant,
+                }
+
+                let route = Route::new_no_state("/hello");
+                let switched = Test::switch(route).expect("Should produce item - test");
+                assert_eq!(
+                    switched,
+                    Test::Variant
+                );
+
+                let route = Route::new_no_state("/some/garbage#/hello");
+                let switched = FragmentAdapter::<Test>::switch(route).expect("Should produce item");
+                assert_eq!(
+                    switched,
+                    FragmentAdapter {
+                        path: "/some/garbage".to_string(),
+                        route: Test::Variant
+                    }
+                )
+            }
+        }
     }
 }

--- a/tests/macro_test/src/lib.rs
+++ b/tests/macro_test/src/lib.rs
@@ -1,7 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use yew_router::{prelude::Route, Switch};
-    use yew_router::switch::Permissive;
+    use yew_router::{prelude::Route, switch::Permissive, Switch};
 
     #[test]
     fn single_enum_variant() {
@@ -474,10 +473,7 @@ mod tests {
 
                 let route = Route::new_no_state("/hello");
                 let switched = Test::switch(route).expect("Should produce item - test");
-                assert_eq!(
-                    switched,
-                    Test::Variant
-                );
+                assert_eq!(switched, Test::Variant);
 
                 let route = Route::new_no_state("/some/garbage#/hello");
                 let switched = FragmentAdapter::<Test>::switch(route).expect("Should produce item");


### PR DESCRIPTION
Fixes https://github.com/yewstack/yew_router/issues/193
Partially fixes https://github.com/yewstack/yew_router/issues/197

What this change does is allow the following syntax to be valid:
`#{*:field}` or `#{3:field}`, whereas before, only `#{field}` was valid. 

The other possibility instead of this PR is to make `#{field}` produce the same tokens as `#{*:field}` when used in a fragment context, but I think its easier for users to not have to deal with a context-sensitive rules about what can be parsed.


For now, this change doesn't make changes to the parser's state machine - in the future, the Fragment state may be modified to allow backtracking to prior states in some form.