### PR TITLE
Cleanup Switch Derive Macro

### DIFF
--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -1,12 +1,8 @@
-use crate::switch::{
-    shadow::{ShadowCaptureVariant, ShadowMatcherToken},
-};
+use crate::switch::shadow::{ShadowCaptureVariant, ShadowMatcherToken};
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::{quote, ToTokens};
-use syn::{
-    export::TokenStream2, parse_macro_input, Data, DeriveInput, Fields, Ident, Variant,
-};
+use syn::{export::TokenStream2, parse_macro_input, Data, DeriveInput, Fields, Ident, Variant};
 
 mod attribute;
 mod enum_impl;
@@ -14,11 +10,9 @@ mod shadow;
 mod struct_impl;
 mod switch_impl;
 
-use self::attribute::AttrToken;
+use self::{attribute::AttrToken, switch_impl::SwitchImpl};
+use crate::switch::{enum_impl::EnumInner, struct_impl::StructInner};
 use yew_router_route_parser::FieldNamingScheme;
-use crate::switch::struct_impl::{StructInner};
-use crate::switch::enum_impl::{EnumInner};
-use self::switch_impl::SwitchImpl;
 
 /// Holds data that is required to derive Switch for a struct or a single enum variant.
 pub struct SwitchItem {
@@ -60,11 +54,12 @@ pub fn switch_impl(input: TokenStream) -> TokenStream {
                     from_route_part: struct_impl::FromRoutePart(&item),
                     build_route_section: struct_impl::BuildRouteSection {
                         switch_item: &item,
-                        item: &Ident::new("self", Span::call_site())
-                    }
-                }
-            }.to_token_stream().into()
-
+                        item: &Ident::new("self", Span::call_site()),
+                    },
+                },
+            }
+            .to_token_stream()
+            .into()
         }
         Data::Enum(de) => {
             let switch_variants = de
@@ -95,14 +90,19 @@ pub fn switch_impl(input: TokenStream) -> TokenStream {
                 target_ident: &ident,
                 generics: &generics,
                 inner: EnumInner {
-                    from_route_part: enum_impl::FromRoutePart { switch_variants: &switch_variants, enum_ident: &ident },
+                    from_route_part: enum_impl::FromRoutePart {
+                        switch_variants: &switch_variants,
+                        enum_ident: &ident,
+                    },
                     build_route_section: enum_impl::BuildRouteSection {
                         switch_items: &switch_variants,
                         enum_ident: &ident,
-                        match_item: &Ident::new("self", Span::call_site())
-                    }
-                }
-            }.to_token_stream().into()
+                        match_item: &Ident::new("self", Span::call_site()),
+                    },
+                },
+            }
+            .to_token_stream()
+            .into()
         }
         Data::Union(_du) => panic!("Deriving FromCaptures not supported for Unions."),
     }
@@ -179,14 +179,9 @@ fn write_for_token(token: &ShadowMatcherToken, naming_scheme: FieldType) -> Toke
 }
 
 
-
-
-
 /// Creates an ident used for destructuring unnamed fields.
 ///
 /// There needs to be a unified way to "mangle" the unnamed fields so they can be destructured,
 fn unnamed_field_index_item(index: usize) -> Ident {
     Ident::new(&format!("__field_{}", index), Span::call_site())
 }
-
-

--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -1,11 +1,9 @@
 use crate::switch::{
-    enum_impl::generate_enum_impl,
     shadow::{ShadowCaptureVariant, ShadowMatcherToken},
-    struct_impl::generate_struct_impl,
 };
 use proc_macro::TokenStream;
 use proc_macro2::Span;
-use quote::quote;
+use quote::{quote, ToTokens};
 use syn::{
     export::TokenStream2, parse_macro_input, Data, DeriveInput, Fields, GenericParam, Generics,
     Ident, Variant,
@@ -19,6 +17,8 @@ mod struct_impl;
 use self::attribute::AttrToken;
 use syn::punctuated::Punctuated;
 use yew_router_route_parser::FieldNamingScheme;
+use crate::switch::struct_impl::StructImpl;
+use crate::switch::enum_impl::EnumImpl;
 
 /// Holds data that is required to derive Switch for a struct or a single enum variant.
 pub struct SwitchItem {
@@ -47,12 +47,17 @@ pub fn switch_impl(input: TokenStream) -> TokenStream {
                 .flatten()
                 .collect::<Vec<_>>();
 
-            let switch_item = SwitchItem {
-                matcher,
-                ident,
-                fields: ds.fields,
-            };
-            generate_struct_impl(switch_item, generics)
+            let mut output = TokenStream2::new();
+
+            StructImpl {
+                item: SwitchItem {
+                    matcher,
+                    ident,
+                    fields: ds.fields,
+                },
+                generics
+            }.to_tokens(&mut output);
+            output.into()
         }
         Data::Enum(de) => {
             let switch_variants = de
@@ -77,7 +82,15 @@ pub fn switch_impl(input: TokenStream) -> TokenStream {
                     }
                 })
                 .collect::<Vec<SwitchItem>>();
-            generate_enum_impl(ident, switch_variants, generics)
+
+            let mut output = TokenStream2::new();
+            EnumImpl {
+                enum_ident: ident,
+                switch_variants,
+                generics
+            }.to_tokens(&mut output);
+            output.into()
+//            generate_enum_impl(ident, switch_variants, generics)
         }
         Data::Union(_du) => panic!("Deriving FromCaptures not supported for Unions."),
     }
@@ -292,27 +305,63 @@ fn unnamed_field_index_item(index: usize) -> Ident {
 }
 
 /// Creates the "impl <X,Y,Z> ::yew_router::Switch for TypeName<X,Y,Z> where etc.." line.
-pub fn impl_line(ident: &Ident, generics: &Generics) -> TokenStream2 {
-    if generics.params.is_empty() {
-        quote! {
-            impl ::yew_router::Switch for #ident
-        }
-    } else {
-        let params = &generics.params;
-        let param_idents = params
-            .iter()
-            .map(|p: &GenericParam| {
-                match p {
-                    GenericParam::Type(ty) => ty.ident.clone(),
-//                    GenericParam::Lifetime(lt) => lt.lifetime, // TODO different type here, must be handled by collecting into a new enum and defining how to convert _that_ to tokens.
-                    _ => unimplemented!("Not all type parameter variants (lifetimes and consts) are supported in Switch")
-                }
-            })
-            .collect::<Punctuated<_,syn::token::Comma>>();
+pub struct ImplSwitch<'a> {
+    target_ident: &'a Ident,
+    generics: &'a Generics
+}
 
-        let where_clause = &generics.where_clause;
-        quote! {
-            impl <#params> ::yew_router::Switch for #ident <#param_idents> #where_clause
-        }
+impl <'a> ToTokens for ImplSwitch<'a> {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+
+        let ident = self.target_ident;
+
+        let line_tokens = if self.generics.params.is_empty() {
+            quote! {
+                impl ::yew_router::Switch for #ident
+            }
+        } else {
+            let params = &self.generics.params;
+            let param_idents = params
+                .iter()
+                .map(|p: &GenericParam| {
+                    match p {
+                        GenericParam::Type(ty) => ty.ident.clone(),
+//                    GenericParam::Lifetime(lt) => lt.lifetime, // TODO different type here, must be handled by collecting into a new enum and defining how to convert _that_ to tokens.
+                        _ => unimplemented!("Not all type parameter variants (lifetimes and consts) are supported in Switch")
+                    }
+                })
+                .collect::<Punctuated<_,syn::token::Comma>>();
+
+            let where_clause = &self.generics.where_clause;
+            quote! {
+                impl <#params> ::yew_router::Switch for #ident <#param_idents> #where_clause
+            }
+        };
+        tokens.extend(line_tokens)
     }
 }
+
+//pub fn impl_line(ident: &Ident, generics: &Generics) -> TokenStream2 {
+//    if generics.params.is_empty() {
+//        quote! {
+//            impl ::yew_router::Switch for #ident
+//        }
+//    } else {
+//        let params = &generics.params;
+//        let param_idents = params
+//            .iter()
+//            .map(|p: &GenericParam| {
+//                match p {
+//                    GenericParam::Type(ty) => ty.ident.clone(),
+////                    GenericParam::Lifetime(lt) => lt.lifetime, // TODO different type here, must be handled by collecting into a new enum and defining how to convert _that_ to tokens.
+//                    _ => unimplemented!("Not all type parameter variants (lifetimes and consts) are supported in Switch")
+//                }
+//            })
+//            .collect::<Punctuated<_,syn::token::Comma>>();
+//
+//        let where_clause = &generics.where_clause;
+//        quote! {
+//            impl <#params> ::yew_router::Switch for #ident <#param_idents> #where_clause
+//        }
+//    }
+//}

--- a/crates/yew_router_macro/src/switch.rs
+++ b/crates/yew_router_macro/src/switch.rs
@@ -17,7 +17,7 @@ mod struct_impl;
 use self::attribute::AttrToken;
 use syn::punctuated::Punctuated;
 use yew_router_route_parser::FieldNamingScheme;
-use crate::switch::struct_impl::StructImpl;
+use crate::switch::struct_impl::{StructInner};
 use crate::switch::enum_impl::EnumImpl;
 
 /// Holds data that is required to derive Switch for a struct or a single enum variant.
@@ -47,17 +47,24 @@ pub fn switch_impl(input: TokenStream) -> TokenStream {
                 .flatten()
                 .collect::<Vec<_>>();
 
-            let mut output = TokenStream2::new();
+            let item = SwitchItem {
+                matcher,
+                ident: ident.clone(), // TODO make SwitchItem take references instead.
+                fields: ds.fields,
+            };
 
-            StructImpl {
-                item: SwitchItem {
-                    matcher,
-                    ident,
-                    fields: ds.fields,
-                },
-                generics
-            }.to_tokens(&mut output);
-            output.into()
+            ImplSwitch {
+                target_ident: &ident,
+                generics: &generics,
+                inner: StructInner {
+                    from_route_part: struct_impl::FromRoutePart(&item),
+                    build_route_section: struct_impl::BuildRouteSection {
+                        switch_item: &item,
+                        item: &Ident::new("self", Span::call_site())
+                    }
+                }
+            }.to_token_stream().into()
+
         }
         Data::Enum(de) => {
             let switch_variants = de
@@ -238,64 +245,7 @@ pub fn build_serializer_for_enum(
     }
 }
 
-pub fn build_serializer_for_struct(switch_item: &SwitchItem, item: &Ident) -> TokenStream2 {
-    let SwitchItem {
-        matcher,
-        ident,
-        fields,
-    } = switch_item;
-    let destructor_and_writers = match fields {
-        Fields::Named(fields_named) => {
-            let field_names = fields_named
-                .named
-                .iter()
-                .filter_map(|named| named.ident.as_ref());
-            let writers = matcher
-                .iter()
-                .map(|token| write_for_token(token, FieldType::Named));
-            quote! {
-                let #ident{#(#field_names),*} = #item;
-                #(#writers)*
-            }
-        }
-        Fields::Unnamed(fields_unnamed) => {
-            let field_names = fields_unnamed
-                .unnamed
-                .iter()
-                .enumerate()
-                .map(|(index, _)| unnamed_field_index_item(index));
-            let mut item_count = 0;
-            let writers = matcher.iter().map(|token| {
-                if let ShadowMatcherToken::Capture(_) = &token {
-                    let ts = write_for_token(token, FieldType::Unnamed { index: item_count });
-                    item_count += 1;
-                    ts
-                } else {
-                    // Its either a literal, or something that will panic currently
-                    write_for_token(token, FieldType::Unit)
-                }
-            });
-            quote! {
-                let #ident(#(#field_names),*) = #item;
-                #(#writers)*
-            }
-        }
-        Fields::Unit => {
-            let writers = matcher
-                .iter()
-                .map(|token| write_for_token(token, FieldType::Unit));
-            quote! {
-                #(#writers)*
-            }
-        }
-    };
-    quote! {
-        use ::std::fmt::Write as _;
-        let mut state: Option<__T> = None;
-        #destructor_and_writers
-        return state;
-    }
-}
+
 
 /// Creates an ident used for destructuring unnamed fields.
 ///
@@ -305,19 +255,23 @@ fn unnamed_field_index_item(index: usize) -> Ident {
 }
 
 /// Creates the "impl <X,Y,Z> ::yew_router::Switch for TypeName<X,Y,Z> where etc.." line.
-pub struct ImplSwitch<'a> {
+pub struct ImplSwitch<'a, T: ToTokens> {
     target_ident: &'a Ident,
-    generics: &'a Generics
+    generics: &'a Generics,
+    inner: T
 }
 
-impl <'a> ToTokens for ImplSwitch<'a> {
+impl <'a, T: ToTokens> ToTokens for ImplSwitch<'a, T> {
     fn to_tokens(&self, tokens: &mut TokenStream2) {
 
         let ident = self.target_ident;
+        let inner = &self.inner;
 
         let line_tokens = if self.generics.params.is_empty() {
             quote! {
-                impl ::yew_router::Switch for #ident
+                impl ::yew_router::Switch for #ident {
+                    #inner
+                }
             }
         } else {
             let params = &self.generics.params;
@@ -335,33 +289,11 @@ impl <'a> ToTokens for ImplSwitch<'a> {
             let where_clause = &self.generics.where_clause;
             quote! {
                 impl <#params> ::yew_router::Switch for #ident <#param_idents> #where_clause
+                {
+                    #inner
+                }
             }
         };
         tokens.extend(line_tokens)
     }
 }
-
-//pub fn impl_line(ident: &Ident, generics: &Generics) -> TokenStream2 {
-//    if generics.params.is_empty() {
-//        quote! {
-//            impl ::yew_router::Switch for #ident
-//        }
-//    } else {
-//        let params = &generics.params;
-//        let param_idents = params
-//            .iter()
-//            .map(|p: &GenericParam| {
-//                match p {
-//                    GenericParam::Type(ty) => ty.ident.clone(),
-////                    GenericParam::Lifetime(lt) => lt.lifetime, // TODO different type here, must be handled by collecting into a new enum and defining how to convert _that_ to tokens.
-//                    _ => unimplemented!("Not all type parameter variants (lifetimes and consts) are supported in Switch")
-//                }
-//            })
-//            .collect::<Punctuated<_,syn::token::Comma>>();
-//
-//        let where_clause = &generics.where_clause;
-//        quote! {
-//            impl <#params> ::yew_router::Switch for #ident <#param_idents> #where_clause
-//        }
-//    }
-//}

--- a/crates/yew_router_macro/src/switch/enum_impl.rs
+++ b/crates/yew_router_macro/src/switch/enum_impl.rs
@@ -1,10 +1,9 @@
-use proc_macro2::{TokenStream};
+use proc_macro2::TokenStream;
 use quote::quote;
 use syn::export::ToTokens;
 
 
-pub use self::build_route_section::BuildRouteSection;
-pub use self::from_route_part::FromRoutePart;
+pub use self::{build_route_section::BuildRouteSection, from_route_part::FromRoutePart};
 
 mod build_route_section;
 mod from_route_part;
@@ -12,16 +11,18 @@ mod from_route_part;
 
 pub struct EnumInner<'a> {
     pub from_route_part: FromRoutePart<'a>,
-    pub build_route_section: BuildRouteSection<'a>
+    pub build_route_section: BuildRouteSection<'a>,
 }
 
-impl <'a> ToTokens for EnumInner<'a> {
+impl<'a> ToTokens for EnumInner<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let EnumInner { from_route_part, build_route_section } = self;
+        let EnumInner {
+            from_route_part,
+            build_route_section,
+        } = self;
         tokens.extend(quote! {
             #from_route_part
             #build_route_section
         });
     }
 }
-

--- a/crates/yew_router_macro/src/switch/enum_impl.rs
+++ b/crates/yew_router_macro/src/switch/enum_impl.rs
@@ -1,192 +1,27 @@
-use crate::switch::{build_serializer_for_enum, SwitchItem, ImplSwitch};
-use proc_macro2::Span;
+use proc_macro2::{TokenStream};
 use quote::quote;
-use syn::{export::TokenStream2, Field, Fields, Generics, Ident, Type};
 use syn::export::ToTokens;
 
 
-pub struct EnumImpl {
-    pub enum_ident: Ident,
-    pub switch_variants: Vec<SwitchItem>,
-    pub generics: Generics
+pub use self::build_route_section::BuildRouteSection;
+pub use self::from_route_part::FromRoutePart;
+
+mod build_route_section;
+mod from_route_part;
+
+
+pub struct InnerEnum<'a> {
+    pub from_route_part: FromRoutePart<'a>,
+    pub build_route_section: BuildRouteSection<'a>
 }
 
-impl ToTokens for EnumImpl {
-    fn to_tokens(&self, tokens: &mut TokenStream2) {
-
-        let variant_matchers = self.switch_variants.iter().map(|sv| {
-            let SwitchItem {
-                matcher,
-                ident,
-                fields,
-            } = sv;
-            let build_from_captures = build_variant_from_captures(&self.enum_ident, ident, fields);
-            let matcher = super::build_matcher_from_tokens(&matcher);
-
-            quote! {
-                #matcher
-                #build_from_captures
-            }
+impl <'a> ToTokens for InnerEnum<'a> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let InnerEnum { from_route_part, build_route_section } = self;
+        tokens.extend(quote! {
+            #from_route_part
+            #build_route_section
         });
-
-        let match_item = Ident::new("self", Span::call_site());
-        let serializer = build_serializer_for_enum(&self.switch_variants, &self.enum_ident, &match_item);
-
-        let inner = quote! {
-            fn from_route_part<__T>(route: String, mut state: Option<__T>) -> (::std::option::Option<Self>, ::std::option::Option<__T>) {
-                let route_string = route;
-                #(#variant_matchers)*
-
-                return (::std::option::Option::None, state)
-            }
-
-            fn build_route_section<__T>(self, mut buf: &mut ::std::string::String) -> ::std::option::Option<__T> {
-                #serializer
-            }
-        };
-
-        let token_stream = ImplSwitch {
-            target_ident: &self.enum_ident,
-            generics: &self.generics,
-            inner
-        }.to_token_stream();
-
-        tokens.extend(token_stream)
     }
 }
 
-
-/// Once the 'captures' exists, attempt to populate the fields from the list of captures.
-fn build_variant_from_captures(
-    enum_ident: &Ident,
-    variant_ident: &Ident,
-    fields: &Fields,
-) -> TokenStream2 {
-    match fields {
-        Fields::Named(named_fields) => {
-            let fields: Vec<TokenStream2> = named_fields
-                .named
-                .iter()
-                .filter_map(|field: &Field| {
-                    let field_ty: &Type = &field.ty;
-                    field.ident.as_ref().map(|i: &Ident| {
-                        let key = i.to_string();
-                        (i, key, field_ty)
-                    })
-                })
-                .map(|(field_name, key, field_ty): (&Ident, String, &Type)| {
-                    quote! {
-                        #field_name: {
-                            let (v, s) = match captures.remove(#key) {
-                                ::std::option::Option::Some(value) => {
-                                    <#field_ty as ::yew_router::Switch>::from_route_part(
-                                        value,
-                                        state,
-                                    )
-                                }
-                                ::std::option::Option::None => {
-                                    (
-                                        <#field_ty as ::yew_router::Switch>::key_not_available(),
-                                        state,
-                                    )
-                                }
-                            };
-                            match v {
-                                ::std::option::Option::Some(val) => {
-                                    state = s; // Set state for the next var.
-                                    val
-                                },
-                                ::std::option::Option::None => return (None, s) // Failed
-                            }
-                        }
-                    }
-                })
-                .collect();
-
-            quote! {
-                let mut state = if let ::std::option::Option::Some(mut captures) = matcher.capture_route_into_map(&route_string).ok().map(|x| x.1) {
-                    let create_item = || {
-                         (
-                            ::std::option::Option::Some(
-                                #enum_ident::#variant_ident {
-                                    #(#fields),*
-                                }
-                            ),
-                            state
-                        )
-                    };
-                    let (val, state) = create_item();
-
-                    if val.is_some() {
-                        return (val, state);
-                    }
-                    state
-                } else {
-                    state
-                };
-            }
-        }
-        Fields::Unnamed(unnamed_fields) => {
-            let fields = unnamed_fields.unnamed.iter().map(|f: &Field| {
-                let field_ty = &f.ty;
-                quote! {
-                    {
-                        let (v, s) = match drain.next() {
-                            ::std::option::Option::Some(value) => {
-                                <#field_ty as ::yew_router::Switch>::from_route_part(
-                                    value,
-                                    state,
-                                )
-                            },
-                            ::std::option::Option::None => {
-                                (
-                                    <#field_ty as ::yew_router::Switch>::key_not_available(),
-                                    state,
-                                )
-                            }
-                        };
-                        match v {
-                            ::std::option::Option::Some(val) => {
-                                state = s; // Set state for the next var.
-                                val
-                            },
-                            ::std::option::Option::None => return (None, s) // Failed
-                        }
-                    }
-                }
-            });
-
-            quote! {
-                let mut state = if let ::std::option::Option::Some(mut captures) = matcher.capture_route_into_vec(&route_string).ok().map(|x| x.1) {
-                    let mut drain = captures.drain(..);
-                    let create_item = || {
-                         (
-                            ::std::option::Option::Some(
-                                #enum_ident::#variant_ident(
-                                    #(#fields),*
-                                )
-                            ),
-                            state
-                        )
-                    };
-                    let (val, state) = create_item();
-                    if val.is_some() {
-                        return (val, state);
-                    }
-                    state
-                } else {
-                    state
-                };
-            }
-        }
-        Fields::Unit => {
-            quote! {
-                let mut state = if let ::std::option::Option::Some(_captures) = matcher.capture_route_into_map(&route_string).ok().map(|x| x.1) {
-                    return (::std::option::Option::Some(#enum_ident::#variant_ident), state);
-                } else {
-                    state
-                };
-            }
-        }
-    }
-}

--- a/crates/yew_router_macro/src/switch/enum_impl.rs
+++ b/crates/yew_router_macro/src/switch/enum_impl.rs
@@ -10,14 +10,14 @@ mod build_route_section;
 mod from_route_part;
 
 
-pub struct InnerEnum<'a> {
+pub struct EnumInner<'a> {
     pub from_route_part: FromRoutePart<'a>,
     pub build_route_section: BuildRouteSection<'a>
 }
 
-impl <'a> ToTokens for InnerEnum<'a> {
+impl <'a> ToTokens for EnumInner<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let InnerEnum { from_route_part, build_route_section } = self;
+        let EnumInner { from_route_part, build_route_section } = self;
         tokens.extend(quote! {
             #from_route_part
             #build_route_section

--- a/crates/yew_router_macro/src/switch/enum_impl/build_route_section.rs
+++ b/crates/yew_router_macro/src/switch/enum_impl/build_route_section.rs
@@ -1,20 +1,23 @@
-use syn::export::{ToTokens, TokenStream2};
-use proc_macro2::{TokenStream, Ident};
-use crate::switch::{SwitchItem, write_for_token, FieldType, unnamed_field_index_item};
-use syn::Fields;
-use crate::switch::shadow::ShadowMatcherToken;
+use crate::switch::{
+    shadow::ShadowMatcherToken, unnamed_field_index_item, write_for_token, FieldType, SwitchItem,
+};
+use proc_macro2::{Ident, TokenStream};
 use quote::quote;
+use syn::{
+    export::{ToTokens, TokenStream2},
+    Fields,
+};
 
 pub struct BuildRouteSection<'a> {
     pub switch_items: &'a [SwitchItem],
     pub enum_ident: &'a Ident,
-    pub match_item: &'a Ident
+    pub match_item: &'a Ident,
 }
 
-impl <'a> ToTokens for BuildRouteSection<'a> {
+impl<'a> ToTokens for BuildRouteSection<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-
-        let serializer = build_serializer_for_enum(self.switch_items, self.enum_ident, self.match_item );
+        let serializer =
+            build_serializer_for_enum(self.switch_items, self.enum_ident, self.match_item);
 
         tokens.extend(quote!{
             fn build_route_section<__T>(self, mut buf: &mut ::std::string::String) -> ::std::option::Option<__T> {

--- a/crates/yew_router_macro/src/switch/enum_impl/build_route_section.rs
+++ b/crates/yew_router_macro/src/switch/enum_impl/build_route_section.rs
@@ -1,0 +1,97 @@
+use syn::export::{ToTokens, TokenStream2};
+use proc_macro2::{TokenStream, Ident};
+use crate::switch::{SwitchItem, write_for_token, FieldType, unnamed_field_index_item};
+use syn::Fields;
+use crate::switch::shadow::ShadowMatcherToken;
+use quote::quote;
+
+pub struct BuildRouteSection<'a> {
+    pub switch_items: &'a [SwitchItem],
+    pub enum_ident: &'a Ident,
+    pub match_item: &'a Ident
+}
+
+impl <'a> ToTokens for BuildRouteSection<'a> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+
+        let serializer = build_serializer_for_enum(self.switch_items, self.enum_ident, self.match_item );
+
+        tokens.extend(quote!{
+            fn build_route_section<__T>(self, mut buf: &mut ::std::string::String) -> ::std::option::Option<__T> {
+                #serializer
+            }
+        });
+    }
+}
+
+/// The serializer makes up the body of `build_route_section`.
+pub fn build_serializer_for_enum(
+    switch_items: &[SwitchItem],
+    enum_ident: &Ident,
+    match_item: &Ident,
+) -> TokenStream2 {
+    let variants = switch_items.iter().map(|switch_item: &SwitchItem| {
+        let SwitchItem {
+            matcher,
+            ident,
+            fields,
+        } = switch_item;
+        match fields {
+            Fields::Named(fields_named) => {
+                let field_names = fields_named
+                    .named
+                    .iter()
+                    .filter_map(|named| named.ident.as_ref());
+                let writers = matcher
+                    .iter()
+                    .map(|token| write_for_token(token, FieldType::Named));
+                quote! {
+                    #enum_ident::#ident{#(#field_names),*} => {
+                        #(#writers)*
+                    }
+                }
+            }
+            Fields::Unnamed(fields_unnamed) => {
+                let field_names = fields_unnamed
+                    .unnamed
+                    .iter()
+                    .enumerate()
+                    .map(|(index, _)| unnamed_field_index_item(index));
+                let mut item_count = 0;
+                let writers = matcher.iter().map(|token| {
+                    if let ShadowMatcherToken::Capture(_) = &token {
+                        let ts = write_for_token(token, FieldType::Unnamed { index: item_count });
+                        item_count += 1;
+                        ts
+                    } else {
+                        // Its either a literal, or something that will panic currently
+                        write_for_token(token, FieldType::Unit)
+                    }
+                });
+                quote! {
+                    #enum_ident::#ident(#(#field_names),*) => {
+                        #(#writers)*
+                    }
+                }
+            }
+            Fields::Unit => {
+                let writers = matcher
+                    .iter()
+                    .map(|token| write_for_token(token, FieldType::Unit));
+                quote! {
+                    #enum_ident::#ident => {
+                        #(#writers)*
+                    }
+                }
+            }
+        }
+    });
+    quote! {
+        use ::std::fmt::Write as __Write;
+        let mut state: Option<__T> = None;
+        match #match_item {
+            #(#variants)*,
+        }
+        return state;
+    }
+}

--- a/crates/yew_router_macro/src/switch/enum_impl/from_route_part.rs
+++ b/crates/yew_router_macro/src/switch/enum_impl/from_route_part.rs
@@ -1,0 +1,174 @@
+use syn::export::{ToTokens, TokenStream2};
+use proc_macro2::{TokenStream, Ident};
+use crate::switch::SwitchItem;
+use syn::{Fields, Type, Field};
+use quote::quote;
+
+pub struct FromRoutePart<'a> {
+    pub switch_variants: &'a [SwitchItem],
+    pub enum_ident: &'a Ident
+}
+
+
+impl <'a> ToTokens for FromRoutePart<'a> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let variant_matchers = self.switch_variants.iter().map(|sv| {
+            let SwitchItem {
+                matcher,
+                ident,
+                fields,
+            } = sv;
+            let build_from_captures = build_variant_from_captures(&self.enum_ident, ident, fields);
+            let matcher = super::super::build_matcher_from_tokens(&matcher);
+
+            quote! {
+                #matcher
+                #build_from_captures
+            }
+        });
+
+        tokens.extend(quote!{
+            fn from_route_part<__T>(route: String, mut state: Option<__T>) -> (::std::option::Option<Self>, ::std::option::Option<__T>) {
+                let route_string = route;
+                #(#variant_matchers)*
+
+                    return (::std::option::Option::None, state)
+            }
+        });
+    }
+}
+
+/// Once the 'captures' exists, attempt to populate the fields from the list of captures.
+fn build_variant_from_captures(
+    enum_ident: &Ident,
+    variant_ident: &Ident,
+    fields: &Fields,
+) -> TokenStream2 {
+    match fields {
+        Fields::Named(named_fields) => {
+            let fields: Vec<TokenStream2> = named_fields
+                .named
+                .iter()
+                .filter_map(|field: &Field| {
+                    let field_ty: &Type = &field.ty;
+                    field.ident.as_ref().map(|i: &Ident| {
+                        let key = i.to_string();
+                        (i, key, field_ty)
+                    })
+                })
+                .map(|(field_name, key, field_ty): (&Ident, String, &Type)| {
+                    quote! {
+                        #field_name: {
+                            let (v, s) = match captures.remove(#key) {
+                                ::std::option::Option::Some(value) => {
+                                    <#field_ty as ::yew_router::Switch>::from_route_part(
+                                        value,
+                                        state,
+                                    )
+                                }
+                                ::std::option::Option::None => {
+                                    (
+                                        <#field_ty as ::yew_router::Switch>::key_not_available(),
+                                        state,
+                                    )
+                                }
+                            };
+                            match v {
+                                ::std::option::Option::Some(val) => {
+                                    state = s; // Set state for the next var.
+                                    val
+                                },
+                                ::std::option::Option::None => return (None, s) // Failed
+                            }
+                        }
+                    }
+                })
+                .collect();
+
+            quote! {
+                let mut state = if let ::std::option::Option::Some(mut captures) = matcher.capture_route_into_map(&route_string).ok().map(|x| x.1) {
+                    let create_item = || {
+                         (
+                            ::std::option::Option::Some(
+                                #enum_ident::#variant_ident {
+                                    #(#fields),*
+                                }
+                            ),
+                            state
+                        )
+                    };
+                    let (val, state) = create_item();
+
+                    if val.is_some() {
+                        return (val, state);
+                    }
+                    state
+                } else {
+                    state
+                };
+            }
+        }
+        Fields::Unnamed(unnamed_fields) => {
+            let fields = unnamed_fields.unnamed.iter().map(|f: &Field| {
+                let field_ty = &f.ty;
+                quote! {
+                    {
+                        let (v, s) = match drain.next() {
+                            ::std::option::Option::Some(value) => {
+                                <#field_ty as ::yew_router::Switch>::from_route_part(
+                                    value,
+                                    state,
+                                )
+                            },
+                            ::std::option::Option::None => {
+                                (
+                                    <#field_ty as ::yew_router::Switch>::key_not_available(),
+                                    state,
+                                )
+                            }
+                        };
+                        match v {
+                            ::std::option::Option::Some(val) => {
+                                state = s; // Set state for the next var.
+                                val
+                            },
+                            ::std::option::Option::None => return (None, s) // Failed
+                        }
+                    }
+                }
+            });
+
+            quote! {
+                let mut state = if let ::std::option::Option::Some(mut captures) = matcher.capture_route_into_vec(&route_string).ok().map(|x| x.1) {
+                    let mut drain = captures.drain(..);
+                    let create_item = || {
+                         (
+                            ::std::option::Option::Some(
+                                #enum_ident::#variant_ident(
+                                    #(#fields),*
+                                )
+                            ),
+                            state
+                        )
+                    };
+                    let (val, state) = create_item();
+                    if val.is_some() {
+                        return (val, state);
+                    }
+                    state
+                } else {
+                    state
+                };
+            }
+        }
+        Fields::Unit => {
+            quote! {
+                let mut state = if let ::std::option::Option::Some(_captures) = matcher.capture_route_into_map(&route_string).ok().map(|x| x.1) {
+                    return (::std::option::Option::Some(#enum_ident::#variant_ident), state);
+                } else {
+                    state
+                };
+            }
+        }
+    }
+}

--- a/crates/yew_router_macro/src/switch/enum_impl/from_route_part.rs
+++ b/crates/yew_router_macro/src/switch/enum_impl/from_route_part.rs
@@ -1,16 +1,18 @@
-use syn::export::{ToTokens, TokenStream2};
-use proc_macro2::{TokenStream, Ident};
 use crate::switch::SwitchItem;
-use syn::{Fields, Type, Field};
+use proc_macro2::{Ident, TokenStream};
 use quote::quote;
+use syn::{
+    export::{ToTokens, TokenStream2},
+    Field, Fields, Type,
+};
 
 pub struct FromRoutePart<'a> {
     pub switch_variants: &'a [SwitchItem],
-    pub enum_ident: &'a Ident
+    pub enum_ident: &'a Ident,
 }
 
 
-impl <'a> ToTokens for FromRoutePart<'a> {
+impl<'a> ToTokens for FromRoutePart<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let variant_matchers = self.switch_variants.iter().map(|sv| {
             let SwitchItem {

--- a/crates/yew_router_macro/src/switch/struct_impl.rs
+++ b/crates/yew_router_macro/src/switch/struct_impl.rs
@@ -1,8 +1,7 @@
-use proc_macro2::{TokenStream};
+pub use self::{build_route_section::BuildRouteSection, from_route_part::FromRoutePart};
+use proc_macro2::TokenStream;
 use quote::quote;
 use syn::export::ToTokens;
-pub use self::build_route_section::BuildRouteSection;
-pub use self::from_route_part::FromRoutePart;
 
 mod build_route_section;
 mod from_route_part;
@@ -10,16 +9,16 @@ mod from_route_part;
 
 pub struct StructInner<'a> {
     pub from_route_part: FromRoutePart<'a>,
-    pub build_route_section: BuildRouteSection<'a>
+    pub build_route_section: BuildRouteSection<'a>,
 }
 
-impl <'a> ToTokens for StructInner<'a> {
+impl<'a> ToTokens for StructInner<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let StructInner {
             from_route_part,
-            build_route_section
+            build_route_section,
         } = self;
-        tokens.extend(quote!{
+        tokens.extend(quote! {
              #from_route_part
              #build_route_section
         })

--- a/crates/yew_router_macro/src/switch/struct_impl/build_route_section.rs
+++ b/crates/yew_router_macro/src/switch/struct_impl/build_route_section.rs
@@ -1,18 +1,21 @@
-use syn::export::{ToTokens, TokenStream2};
-use crate::switch::{SwitchItem, write_for_token, FieldType, unnamed_field_index_item};
+use crate::switch::{
+    shadow::ShadowMatcherToken, unnamed_field_index_item, write_for_token, FieldType, SwitchItem,
+};
 use proc_macro2::{Ident, TokenStream};
-use syn::Fields;
-use crate::switch::shadow::ShadowMatcherToken;
 use quote::quote;
+use syn::{
+    export::{ToTokens, TokenStream2},
+    Fields,
+};
 
 pub struct BuildRouteSection<'a> {
     pub switch_item: &'a SwitchItem,
-    pub item: &'a Ident
+    pub item: &'a Ident,
 }
 
-impl <'a> ToTokens for BuildRouteSection<'a> {
+impl<'a> ToTokens for BuildRouteSection<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let serializer = build_serializer_for_struct(self.switch_item, self.item );
+        let serializer = build_serializer_for_struct(self.switch_item, self.item);
         tokens.extend(quote! {
             fn build_route_section<__T>(self, mut buf: &mut ::std::string::String) -> ::std::option::Option<__T> {
                 #serializer
@@ -20,8 +23,6 @@ impl <'a> ToTokens for BuildRouteSection<'a> {
         })
     }
 }
-
-
 
 
 pub fn build_serializer_for_struct(switch_item: &SwitchItem, item: &Ident) -> TokenStream2 {

--- a/crates/yew_router_macro/src/switch/struct_impl/build_route_section.rs
+++ b/crates/yew_router_macro/src/switch/struct_impl/build_route_section.rs
@@ -1,0 +1,84 @@
+use syn::export::{ToTokens, TokenStream2};
+use crate::switch::{SwitchItem, write_for_token, FieldType, unnamed_field_index_item};
+use proc_macro2::{Ident, TokenStream};
+use syn::Fields;
+use crate::switch::shadow::ShadowMatcherToken;
+use quote::quote;
+
+pub struct BuildRouteSection<'a> {
+    pub switch_item: &'a SwitchItem,
+    pub item: &'a Ident
+}
+
+impl <'a> ToTokens for BuildRouteSection<'a> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let serializer = build_serializer_for_struct(self.switch_item, self.item );
+        tokens.extend(quote! {
+            fn build_route_section<__T>(self, mut buf: &mut ::std::string::String) -> ::std::option::Option<__T> {
+                #serializer
+            }
+        })
+    }
+}
+
+
+
+
+pub fn build_serializer_for_struct(switch_item: &SwitchItem, item: &Ident) -> TokenStream2 {
+    let SwitchItem {
+        matcher,
+        ident,
+        fields,
+    } = switch_item;
+    let destructor_and_writers = match fields {
+        Fields::Named(fields_named) => {
+            let field_names = fields_named
+                .named
+                .iter()
+                .filter_map(|named| named.ident.as_ref());
+            let writers = matcher
+                .iter()
+                .map(|token| write_for_token(token, FieldType::Named));
+            quote! {
+                let #ident{#(#field_names),*} = #item;
+                #(#writers)*
+            }
+        }
+        Fields::Unnamed(fields_unnamed) => {
+            let field_names = fields_unnamed
+                .unnamed
+                .iter()
+                .enumerate()
+                .map(|(index, _)| unnamed_field_index_item(index));
+            let mut item_count = 0;
+            let writers = matcher.iter().map(|token| {
+                if let ShadowMatcherToken::Capture(_) = &token {
+                    let ts = write_for_token(token, FieldType::Unnamed { index: item_count });
+                    item_count += 1;
+                    ts
+                } else {
+                    // Its either a literal, or something that will panic currently
+                    write_for_token(token, FieldType::Unit)
+                }
+            });
+            quote! {
+                let #ident(#(#field_names),*) = #item;
+                #(#writers)*
+            }
+        }
+        Fields::Unit => {
+            let writers = matcher
+                .iter()
+                .map(|token| write_for_token(token, FieldType::Unit));
+            quote! {
+                #(#writers)*
+            }
+        }
+    };
+    quote! {
+        use ::std::fmt::Write as _;
+        let mut state: Option<__T> = None;
+        #destructor_and_writers
+        return state;
+    }
+}

--- a/crates/yew_router_macro/src/switch/struct_impl/from_route_part.rs
+++ b/crates/yew_router_macro/src/switch/struct_impl/from_route_part.rs
@@ -1,0 +1,147 @@
+use syn::export::{ToTokens, TokenStream2};
+//use crate::switch::{SwitchItem, write_for_token, FieldType, unnamed_field_index_item};
+use proc_macro2::{Ident, TokenStream};
+use syn::{Fields, Field, Type};
+use quote::quote;
+use crate::switch::SwitchItem;
+
+
+pub struct FromRoutePart<'a> (pub &'a SwitchItem);
+
+impl <'a> ToTokens for FromRoutePart<'a> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let SwitchItem {
+            matcher,
+            ident,
+            fields,
+        } = &self.0;
+
+        let matcher = super::super::build_matcher_from_tokens(&matcher);
+        let build_from_captures = build_struct_from_captures(ident, fields);
+
+        tokens.extend(quote! {
+
+            fn from_route_part<__T>(route: String, mut state: Option<__T>) -> (::std::option::Option<Self>, ::std::option::Option<__T>) {
+
+                #matcher
+                let route_string = route;
+
+                #build_from_captures
+
+                return (::std::option::Option::None, state)
+            }
+
+        })
+    }
+}
+
+fn build_struct_from_captures(ident: &Ident, fields: &Fields) -> TokenStream2 {
+    match fields {
+        Fields::Named(named_fields) => {
+            let fields: Vec<TokenStream2> = named_fields
+                .named
+                .iter()
+                .filter_map(|field: &Field| {
+                    let field_ty: &Type = &field.ty;
+                    field.ident.as_ref().map(|i| {
+                        let key = i.to_string();
+                        (i, key, field_ty)
+                    })
+                })
+                .map(|(field_name, key, field_ty): (&Ident, String, &Type)| {
+                    quote! {
+                        #field_name: {
+                            let (v, s) = match captures.remove(#key) {
+                                ::std::option::Option::Some(value) => {
+                                    <#field_ty as ::yew_router::Switch>::from_route_part(
+                                        value,
+                                        state,
+                                    )
+                                }
+                                ::std::option::Option::None => {
+                                    (
+                                        <#field_ty as ::yew_router::Switch>::key_not_available(),
+                                        state,
+                                    )
+                                }
+                            };
+                            match v {
+                                ::std::option::Option::Some(val) => {
+                                    state = s; // Set state for the next var.
+                                    val
+                                },
+                                ::std::option::Option::None => return (::std::option::Option::None, s) // Failed
+                            }
+                        }
+                    }
+                })
+                .collect();
+
+            return quote! {
+                if let ::std::option::Option::Some(mut captures) = matcher.capture_route_into_map(&route_string).ok().map(|x| x.1) {
+                    return (
+                        ::std::option::Option::Some(
+                            #ident {
+                                #(#fields),*
+                            }
+                        ),
+                        state
+                    );
+                };
+            };
+        }
+        Fields::Unnamed(unnamed_fields) => {
+            let fields = unnamed_fields.unnamed.iter().map(|f: &Field| {
+                let field_ty = &f.ty;
+                quote! {
+                    {
+                        let (v, s) = match drain.next() {
+                            ::std::option::Option::Some(value) => {
+                                <#field_ty as ::yew_router::Switch>::from_route_part(
+                                    value,
+                                    state,
+                                )
+                            },
+                            ::std::option::Option::None => {
+                                (
+                                    <#field_ty as ::yew_router::Switch>::key_not_available(),
+                                    state,
+                                )
+                            }
+                        };
+                        match v {
+                            ::std::option::Option::Some(val) => {
+                                state = s; // Set state for the next var.
+                                val
+                            },
+                            ::std::option::Option::None => return (::std::option::Option::None, s) // Failed
+                        }
+                    }
+                }
+            });
+
+            quote! {
+                if let Some(mut captures) = matcher.capture_route_into_vec(&route_string).ok().map(|x| x.1) {
+                    let mut drain = captures.drain(..);
+                    return (
+                        ::std::option::Option::Some(
+                            #ident(
+                                #(#fields),*
+                            )
+                        ),
+                        state
+                    );
+                };
+            }
+        }
+        Fields::Unit => {
+            return quote! {
+                let mut state = if let ::std::option::Option::Some(_captures) = matcher.capture_route_into_map(&route_string).ok().map(|x| x.1) {
+                    return (::std::option::Option::Some(#ident), state);
+                } else {
+                    state
+                };
+            }
+        }
+    }
+}

--- a/crates/yew_router_macro/src/switch/struct_impl/from_route_part.rs
+++ b/crates/yew_router_macro/src/switch/struct_impl/from_route_part.rs
@@ -1,14 +1,14 @@
 use syn::export::{ToTokens, TokenStream2};
-//use crate::switch::{SwitchItem, write_for_token, FieldType, unnamed_field_index_item};
-use proc_macro2::{Ident, TokenStream};
-use syn::{Fields, Field, Type};
-use quote::quote;
+// use crate::switch::{SwitchItem, write_for_token, FieldType, unnamed_field_index_item};
 use crate::switch::SwitchItem;
+use proc_macro2::{Ident, TokenStream};
+use quote::quote;
+use syn::{Field, Fields, Type};
 
 
-pub struct FromRoutePart<'a> (pub &'a SwitchItem);
+pub struct FromRoutePart<'a>(pub &'a SwitchItem);
 
-impl <'a> ToTokens for FromRoutePart<'a> {
+impl<'a> ToTokens for FromRoutePart<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let SwitchItem {
             matcher,

--- a/crates/yew_router_macro/src/switch/switch_impl.rs
+++ b/crates/yew_router_macro/src/switch/switch_impl.rs
@@ -1,0 +1,49 @@
+use syn::export::{ToTokens, TokenStream2};
+use proc_macro2::Ident;
+use syn::{Generics, GenericParam};
+use syn::punctuated::Punctuated;
+use quote::quote;
+
+/// Creates the "impl <X,Y,Z> ::yew_router::Switch for TypeName<X,Y,Z> where etc.." line.
+pub struct SwitchImpl<'a, T: ToTokens> {
+    pub target_ident: &'a Ident,
+    pub generics: &'a Generics,
+    pub inner: T
+}
+
+impl <'a, T: ToTokens> ToTokens for SwitchImpl<'a, T> {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+
+        let ident = self.target_ident;
+        let inner = &self.inner;
+
+        let line_tokens = if self.generics.params.is_empty() {
+            quote! {
+                impl ::yew_router::Switch for #ident {
+                    #inner
+                }
+            }
+        } else {
+            let params = &self.generics.params;
+            let param_idents = params
+                .iter()
+                .map(|p: &GenericParam| {
+                    match p {
+                        GenericParam::Type(ty) => ty.ident.clone(),
+//                    GenericParam::Lifetime(lt) => lt.lifetime, // TODO different type here, must be handled by collecting into a new enum and defining how to convert _that_ to tokens.
+                        _ => unimplemented!("Not all type parameter variants (lifetimes and consts) are supported in Switch")
+                    }
+                })
+                .collect::<Punctuated<_,syn::token::Comma>>();
+
+            let where_clause = &self.generics.where_clause;
+            quote! {
+                impl <#params> ::yew_router::Switch for #ident <#param_idents> #where_clause
+                {
+                    #inner
+                }
+            }
+        };
+        tokens.extend(line_tokens)
+    }
+}

--- a/crates/yew_router_macro/src/switch/switch_impl.rs
+++ b/crates/yew_router_macro/src/switch/switch_impl.rs
@@ -5,11 +5,14 @@ use syn::punctuated::Punctuated;
 use quote::quote;
 
 /// Creates the "impl <X,Y,Z> ::yew_router::Switch for TypeName<X,Y,Z> where etc.." line.
-pub struct SwitchImpl<'a, T: ToTokens> {
+///
+/// Then populates the body of the implementation with the specified `T`.
+pub struct SwitchImpl<'a, T> {
     pub target_ident: &'a Ident,
     pub generics: &'a Generics,
     pub inner: T
 }
+
 
 impl <'a, T: ToTokens> ToTokens for SwitchImpl<'a, T> {
     fn to_tokens(&self, tokens: &mut TokenStream2) {

--- a/crates/yew_router_macro/src/switch/switch_impl.rs
+++ b/crates/yew_router_macro/src/switch/switch_impl.rs
@@ -1,22 +1,24 @@
-use syn::export::{ToTokens, TokenStream2};
 use proc_macro2::Ident;
-use syn::{Generics, GenericParam};
-use syn::punctuated::Punctuated;
 use quote::quote;
+use syn::{
+    export::{ToTokens, TokenStream2},
+    punctuated::Punctuated,
+    GenericParam, Generics,
+};
 
+// Todo, consider removing the T here and replacing it with an enum.
 /// Creates the "impl <X,Y,Z> ::yew_router::Switch for TypeName<X,Y,Z> where etc.." line.
 ///
 /// Then populates the body of the implementation with the specified `T`.
 pub struct SwitchImpl<'a, T> {
     pub target_ident: &'a Ident,
     pub generics: &'a Generics,
-    pub inner: T
+    pub inner: T,
 }
 
 
-impl <'a, T: ToTokens> ToTokens for SwitchImpl<'a, T> {
+impl<'a, T: ToTokens> ToTokens for SwitchImpl<'a, T> {
     fn to_tokens(&self, tokens: &mut TokenStream2) {
-
         let ident = self.target_ident;
         let inner = &self.inner;
 


### PR DESCRIPTION
Closes https://github.com/yewstack/yew_router/issues/176


This PR starts outside-in - moving what was formerly functions into datastructures that implement `ToTokens` for the macro entrypoint and a few layers inwards.
There is still work to do, in that some inner macro content might be able to be broken out into more `ToTokens` structs. Conceptually, this might allow sharing implementations between the struct and enum variants in some places.